### PR TITLE
fix(admin): 优化支付详情弹窗显示效果

### DIFF
--- a/src/views/admin/Payments.vue
+++ b/src/views/admin/Payments.vue
@@ -396,7 +396,7 @@ watch(
     </div>
 
     <Dialog v-model:open="showDetail" @update:open="(value) => { if (!value) closeDetail() }">
-      <DialogScrollContent class="w-full max-w-4xl">
+      <DialogScrollContent class="w-full max-w-5xl">
         <DialogHeader>
           <DialogTitle>{{ t('admin.payments.detailTitle') }}</DialogTitle>
         </DialogHeader>
@@ -406,19 +406,19 @@ watch(
             {{ detailError }}
           </div>
           <div v-else-if="detailPayment" class="space-y-6 text-sm text-muted-foreground">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailPaymentId') }}</div>
-                  <div class="text-foreground font-mono mt-1">
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailPaymentId') }}</div>
+                  <div class="text-foreground font-mono text-sm break-all">
                     <IdCell :value="detailPayment.id" />
                   </div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailOrderId') }}</div>
-                  <div class="text-foreground font-mono mt-1">
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailOrderId') }}</div>
+                  <div class="text-foreground font-mono text-sm break-all">
                     <a v-if="detailPayment.order_id" :href="orderLink(detailPayment.order_id)" target="_blank" rel="noopener" class="text-primary underline-offset-4 hover:underline">
                       #{{ detailPayment.order_id }}
                     </a>
@@ -427,16 +427,16 @@ watch(
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailChannel') }}</div>
-                  <div class="text-foreground">{{ detailPayment.channel_name || '-' }}</div>
-                  <div class="text-xs text-muted-foreground mt-1">{{ providerTypeLabel(detailPayment.provider_type) }} / {{ channelTypeLabel(detailPayment.channel_type) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailChannel') }}</div>
+                  <div class="text-foreground text-sm break-words">{{ detailPayment.channel_name || '-' }}</div>
+                  <div class="text-xs text-muted-foreground mt-1 break-words">{{ providerTypeLabel(detailPayment.provider_type) }} / {{ channelTypeLabel(detailPayment.channel_type) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.channelId') }}</div>
-                  <div class="text-foreground font-mono mt-1">
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.channelId') }}</div>
+                  <div class="text-foreground font-mono text-sm break-all">
                     <a v-if="detailPayment.channel_id" :href="channelLink(detailPayment.channel_id)" target="_blank" rel="noopener" class="text-primary underline-offset-4 hover:underline">
                       #{{ detailPayment.channel_id }}
                     </a>
@@ -445,83 +445,83 @@ watch(
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailStatus') }}</div>
-                  <div class="text-foreground">{{ statusLabel(detailPayment.status) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailStatus') }}</div>
+                  <div class="text-foreground text-sm">{{ statusLabel(detailPayment.status) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailAmount') }}</div>
-                  <div class="text-foreground font-mono mt-1">{{ detailPayment.amount }} {{ detailPayment.currency }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailAmount') }}</div>
+                  <div class="text-foreground font-mono text-sm">{{ detailPayment.amount }} {{ detailPayment.currency }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailFeeRate') }}</div>
-                  <div class="text-foreground font-mono mt-1">{{ formatFeeRate(detailPayment.fee_rate) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailFeeRate') }}</div>
+                  <div class="text-foreground font-mono text-sm">{{ formatFeeRate(detailPayment.fee_rate) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailFeeAmount') }}</div>
-                  <div class="text-foreground font-mono mt-1">{{ formatMoney(detailPayment.fee_amount, detailPayment.currency) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailFeeAmount') }}</div>
+                  <div class="text-foreground font-mono text-sm">{{ formatMoney(detailPayment.fee_amount, detailPayment.currency) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailInteraction') }}</div>
-                  <div class="text-foreground">{{ interactionModeLabel(detailPayment.interaction_mode) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailInteraction') }}</div>
+                  <div class="text-foreground text-sm">{{ interactionModeLabel(detailPayment.interaction_mode) }}</div>
                 </CardContent>
               </Card>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailCreatedAt') }}</div>
-                  <div class="text-foreground">{{ formatDate(detailPayment.created_at) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailCreatedAt') }}</div>
+                  <div class="text-foreground text-sm">{{ formatDate(detailPayment.created_at) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailPaidAt') }}</div>
-                  <div class="text-foreground">{{ formatDate(detailPayment.paid_at) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailPaidAt') }}</div>
+                  <div class="text-foreground text-sm">{{ formatDate(detailPayment.paid_at) }}</div>
                 </CardContent>
               </Card>
               <Card class="rounded-lg border-border bg-background shadow-none">
-                <CardContent class="p-3">
-                  <div class="text-xs text-muted-foreground">{{ t('admin.payments.detailExpiredAt') }}</div>
-                  <div class="text-foreground">{{ formatDate(detailPayment.expired_at) }}</div>
+                <CardContent class="p-4">
+                  <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailExpiredAt') }}</div>
+                  <div class="text-foreground text-sm">{{ formatDate(detailPayment.expired_at) }}</div>
                 </CardContent>
               </Card>
             </div>
 
             <Card class="rounded-lg border-border bg-background shadow-none">
-              <CardContent class="p-3">
-                <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailProviderRef') }}</div>
-                <div class="text-foreground break-all">{{ detailPayment.provider_ref || '-' }}</div>
+              <CardContent class="p-4">
+                <div class="text-xs text-muted-foreground mb-3">{{ t('admin.payments.detailProviderRef') }}</div>
+                <div class="text-foreground break-all text-sm">{{ detailPayment.provider_ref || '-' }}</div>
               </CardContent>
             </Card>
 
             <Card v-if="detailPayment.pay_url" class="rounded-lg border-border bg-background shadow-none">
-              <CardContent class="p-3">
-                <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailPayUrl') }}</div>
-                <div class="text-foreground break-all">{{ detailPayment.pay_url }}</div>
+              <CardContent class="p-4">
+                <div class="text-xs text-muted-foreground mb-3">{{ t('admin.payments.detailPayUrl') }}</div>
+                <div class="text-foreground break-all text-sm">{{ detailPayment.pay_url }}</div>
               </CardContent>
             </Card>
 
             <Card v-if="detailPayment.qr_code" class="rounded-lg border-border bg-background shadow-none">
-              <CardContent class="p-3">
-                <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailQrCode') }}</div>
-                <div class="text-foreground break-all">{{ detailPayment.qr_code }}</div>
+              <CardContent class="p-4">
+                <div class="text-xs text-muted-foreground mb-3">{{ t('admin.payments.detailQrCode') }}</div>
+                <div class="text-foreground break-all text-sm">{{ detailPayment.qr_code }}</div>
               </CardContent>
             </Card>
 
             <Card class="rounded-lg border-border bg-background shadow-none">
-              <CardContent class="p-3">
-                <div class="text-xs text-muted-foreground mb-2">{{ t('admin.payments.detailPayload') }}</div>
-                <div class="text-xs text-muted-foreground whitespace-pre-wrap font-mono bg-muted/40 p-3 rounded-lg border border-border">
+              <CardContent class="p-4">
+                <div class="text-xs text-muted-foreground mb-3">{{ t('admin.payments.detailPayload') }}</div>
+                <div class="text-xs text-muted-foreground whitespace-pre-wrap font-mono bg-muted/40 p-4 rounded-lg border border-border overflow-auto max-h-64 break-all word-break-break-all">
                   {{ formatPayload(detailPayment.provider_payload) }}
                 </div>
               </CardContent>
@@ -532,3 +532,10 @@ watch(
     </Dialog>
   </div>
 </template>
+
+<style scoped>
+.break-all {
+  word-break: break-all;
+  overflow-wrap: break-word;
+}
+</style>


### PR DESCRIPTION
## 问题描述

支付详情弹窗在内容较多时，部分信息（如回调内容）会被挤到可视区域外，用户需要滚动才能看到完整内容。

## 修改内容

### 1. 弹窗布局优化
- 将弹窗最大宽度从 `max-w-4xl` 调整为 `max-w-5xl`，提供更多显示空间
- 移除固定高度限制，采用与订单详情一致的自适应滚动方案

### 2. 响应式布局改进
- 将网格断点从 `md:` 调整为 `lg:`，在更大屏幕才分列显示
- 优化移动端和小屏幕设备的显示效果

### 3. 卡片样式统一
- 统一卡片内边距为 `p-4`
- 统一标签间距和文字大小
- 添加 `break-all` 类确保长文本（URL、JSON等）正确换行

### 4. 文本显示优化
- 为支付链接、二维码、平台单号等长文本字段添加自动换行
- 为回调内容 JSON 添加最大高度和滚动功能

## 测试

- [x] 在生产环境测试通过
- [x] 支付详情弹窗所有内容正常显示
- [x] 长文本正确换行，不会溢出容器
- [x] 响应式布局在不同屏幕尺寸下正常工作

## 截图

<img width="1444" height="916" alt="image" src="https://github.com/user-attachments/assets/9346b3bd-97c1-4e5d-825d-51a73c93c8cd" />
