### PR TITLE
feat(auth): add configurable user registration toggle

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1437,6 +1437,14 @@ const messages = {
             topChannelsLimitHint: '范围 1-20，控制榜单返回条数',
           },
         },
+        userRegistration: {
+          title: '用户注册配置',
+          subtitle: '控制前台用户注册行为',
+          enabled: '允许用户注册',
+          enabledHint: '关闭后前台将隐藏注册入口',
+          requireEmailVerify: '注册需要邮箱验证码',
+          requireEmailVerifyHint: '关闭后用户注册时无需输入邮箱验证码',
+        },
         alerts: {
           saveSuccess: '设置已保存',
           saveFailed: '保存失败',
@@ -2885,6 +2893,14 @@ const messages = {
             topChannelsLimitHint: '範圍 1-20，控制榜單回傳筆數',
           },
         },
+        userRegistration: {
+          title: '使用者註冊配置',
+          subtitle: '控制前台使用者註冊行為',
+          enabled: '允許使用者註冊',
+          enabledHint: '關閉後前台將隱藏註冊入口',
+          requireEmailVerify: '註冊需要郵箱驗證碼',
+          requireEmailVerifyHint: '關閉後使用者註冊時無需輸入郵箱驗證碼',
+        },
         alerts: {
           saveSuccess: '設定已保存',
           saveFailed: '保存失敗',
@@ -4332,6 +4348,14 @@ const messages = {
             topChannelsLimit: 'Top channels limit',
             topChannelsLimitHint: 'Range 1-20, controls list size',
           },
+        },
+        userRegistration: {
+          title: 'User Registration',
+          subtitle: 'Control user registration behavior on the storefront',
+          enabled: 'Allow user registration',
+          enabledHint: 'When disabled, the registration entry will be hidden',
+          requireEmailVerify: 'Require email verification code',
+          requireEmailVerifyHint: 'When disabled, users can register without email verification',
         },
         alerts: {
           saveSuccess: 'Settings saved',

--- a/src/views/admin/Settings.vue
+++ b/src/views/admin/Settings.vue
@@ -153,6 +153,10 @@ const form = reactive({
     privacy: createLocalizedField(),
   },
   scripts: [] as SiteScriptItem[],
+  user_registration: {
+    enabled: true,
+    require_email_verify: true,
+  },
 })
 
 const smtpForm = reactive({
@@ -321,6 +325,11 @@ const fetchSettings = async () => {
 
       const scripts = normalizeSiteScripts(data.scripts)
       form.scripts.splice(0, form.scripts.length, ...scripts)
+
+      if (data.user_registration) {
+        form.user_registration.enabled = data.user_registration.enabled !== false
+        form.user_registration.require_email_verify = data.user_registration.require_email_verify !== false
+      }
     }
 
     if (smtpRes.data && smtpRes.data.data) {
@@ -402,6 +411,7 @@ const saveSiteSettings = async () => {
       about: form.about,
       legal: form.legal,
       scripts: form.scripts,
+      user_registration: form.user_registration,
     },
   }
   await adminAPI.updateSettings(payload)
@@ -710,6 +720,28 @@ onMounted(() => {
           <div class="space-y-2">
             <label class="text-xs font-medium text-muted-foreground">{{ t('admin.settings.contact.whatsapp') }}</label>
             <Input v-model="form.contact.whatsapp" :placeholder="t('admin.settings.contact.whatsappPlaceholder')" />
+          </div>
+        </div>
+      </div>
+      <div class="rounded-xl border border-border bg-card">
+        <div class="border-b border-border bg-muted/40 px-6 py-4">
+          <h2 class="text-lg font-semibold">{{ t('admin.settings.userRegistration.title') }}</h2>
+          <p class="mt-1 text-xs text-muted-foreground">{{ t('admin.settings.userRegistration.subtitle') }}</p>
+        </div>
+        <div class="space-y-4 p-6">
+          <div class="flex items-center gap-3 rounded-lg border border-border bg-muted/20 px-4 py-3">
+            <input id="user-reg-enabled" v-model="form.user_registration.enabled" type="checkbox" class="h-4 w-4 accent-primary" />
+            <div>
+              <label for="user-reg-enabled" class="text-sm font-medium">{{ t('admin.settings.userRegistration.enabled') }}</label>
+              <p class="text-xs text-muted-foreground">{{ t('admin.settings.userRegistration.enabledHint') }}</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-3 rounded-lg border border-border bg-muted/20 px-4 py-3">
+            <input id="user-reg-email-verify" v-model="form.user_registration.require_email_verify" type="checkbox" class="h-4 w-4 accent-primary" />
+            <div>
+              <label for="user-reg-email-verify" class="text-sm font-medium">{{ t('admin.settings.userRegistration.requireEmailVerify') }}</label>
+              <p class="text-xs text-muted-foreground">{{ t('admin.settings.userRegistration.requireEmailVerifyHint') }}</p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add two admin-configurable settings for user registration:
- `user_registration.enabled`: enable/disable new user registration
- `user_registration.require_email_verify`: toggle email verification requirement

When registration is disabled, the register endpoint returns an error.
When email verification is disabled, users can register with just email + password.

Both settings default to `true` (current behavior unchanged).

---
Related: dujiao-next/dujiao-next#14, dujiao-next/user#4
