### PR TITLE
fix(admin): avoid stale product detail responses overwriting edit form

### DIFF
--- a/src/views/admin/components/ProductEditModal.vue
+++ b/src/views/admin/components/ProductEditModal.vue
@@ -33,6 +33,7 @@ const submitting = ref(false)
 const isEditing = ref(false)
 const editingIsMapped = ref(false)
 const initialCategoryID = ref<number | null>(null)
+const productLoadVersion = ref(0)
 const fileInput = ref<HTMLInputElement | null>(null)
 const newTag = ref('')
 const currentLang = ref('zh-CN')
@@ -500,6 +501,29 @@ const closeModal = () => {
   emit('update:modelValue', false)
 }
 
+const loadProductForEdit = async (productID: number) => {
+  const currentLoadVersion = ++productLoadVersion.value
+  try {
+    const res = await adminAPI.getProduct(productID)
+    if (
+      currentLoadVersion !== productLoadVersion.value
+      || !props.modelValue
+      || props.productId !== productID
+    ) {
+      return
+    }
+
+    const product = res.data.data
+    editingIsMapped.value = Boolean(product.is_mapped)
+    populateForm(product)
+  } catch (err: any) {
+    if (currentLoadVersion !== productLoadVersion.value) return
+    if (isNotifiedError(err)) return
+    notifyError(t('admin.products.errors.operationFailed', { message: err?.message || '' }))
+    closeModal()
+  }
+}
+
 const handleSubmit = async () => {
   submitting.value = true
   try {
@@ -611,57 +635,23 @@ const uploadImage = async (file: File) => {
   }
 }
 
-// Watch productId to determine create vs edit mode and fetch product details
 watch(
-  () => props.productId,
-  async (newId) => {
-    if (!props.modelValue) return
-    currentLang.value = 'zh-CN'
-    if (newId != null && newId > 0) {
-      // Edit mode
-      isEditing.value = true
-      try {
-        const res = await adminAPI.getProduct(newId)
-        const product = res.data.data
-        editingIsMapped.value = Boolean(product.is_mapped)
-        populateForm(product)
-      } catch (err: any) {
-        if (isNotifiedError(err)) return
-        notifyError(t('admin.products.errors.operationFailed', { message: err?.message || '' }))
-        closeModal()
-      }
-    } else {
-      // Create mode
-      isEditing.value = false
-      editingIsMapped.value = false
-      resetForm()
-    }
-  }
-)
+  [() => props.modelValue, () => props.productId],
+  ([isOpen, productID]) => {
+    productLoadVersion.value += 1
+    if (!isOpen) return
 
-// Also handle when modal opens
-watch(
-  () => props.modelValue,
-  (newVal) => {
-    if (!newVal) return
     currentLang.value = 'zh-CN'
-    if (props.productId != null && props.productId > 0) {
+    if (productID != null && productID > 0) {
       isEditing.value = true
-      adminAPI.getProduct(props.productId).then((res) => {
-        const product = res.data.data
-        editingIsMapped.value = Boolean(product.is_mapped)
-        populateForm(product)
-      }).catch((err: any) => {
-        if (isNotifiedError(err)) return
-        notifyError(t('admin.products.errors.operationFailed', { message: err?.message || '' }))
-        closeModal()
-      })
-    } else {
-      isEditing.value = false
-      editingIsMapped.value = false
-      resetForm()
+      void loadProductForEdit(productID)
+      return
     }
-  }
+
+    isEditing.value = false
+    editingIsMapped.value = false
+    resetForm()
+  },
 )
 </script>
 


### PR DESCRIPTION
﻿## 背景

这个问题的直接根因不在 admin，而在后端。

不过在排查过程中也发现，商品编辑弹窗之前会同时监听 `productId` 和 `modelValue`，打开已有商品时可能并发请求两次商品详情，存在旧请求晚返回并覆盖当前表单状态的竞态风险。

虽然这不是本次分类保存失败的直接原因，但属于真实的状态同步隐患。

## 本次修复

- 将编辑态商品详情加载收敛为单一入口
- 增加最新请求校验，避免旧响应覆盖表单
- 不改变现有 UI 和接口行为

## 设计取向

- 保持现有后台 UI 风格不变
- 不调整弹窗结构
- 不改接口协议
- 仅做最小范围的状态同步修复

## 验证

- 本地验证商品编辑场景下表单回填与保存行为稳定
- `npm.cmd run build` 当前被仓库内已有的无关 TypeScript 问题阻塞，本次改动未新增对应报错

## 依赖

- backend PR: https://github.com/dujiao-next/dujiao-next/pull/38
