### PR TITLE
fix(admin): preserve upstream fulfillment type for mapped products

### DIFF
--- a/src/views/admin/components/ProductEditModal.vue
+++ b/src/views/admin/components/ProductEditModal.vue
@@ -543,7 +543,7 @@ const handleSubmit = async () => {
       max_purchase_quantity: Number.isFinite(normalizedMaxPurchaseQuantity) && normalizedMaxPurchaseQuantity > 0
         ? Math.floor(normalizedMaxPurchaseQuantity)
         : 0,
-      fulfillment_type: form.fulfillment_type,
+      fulfillment_type: editingIsMapped.value ? undefined : form.fulfillment_type,
       manual_stock_total: effectiveManualStockTotal,
       skus: normalizedSKUs,
       is_affiliate_enabled: form.is_affiliate_enabled,


### PR DESCRIPTION
## 功能描述

修复后台编辑对接商品时，将展示用交付类型误写回接口，导致 `fulfillment_type` 从 `upstream` 被覆盖为 `manual` 或 `auto` 的问题。

## 背景

对接商品在后台列表和详情中，会根据上游实际交付方式显示为 `manual` 或 `auto`，方便运营查看库存和交付类型。

不过编辑弹窗提交时，之前会直接把这个展示值作为 `fulfillment_type` 一起提交。这样在保存 mapped 商品的其他字段时，也会把数据库里的真实类型 `upstream` 覆盖掉。随后库存展示会按普通商品逻辑计算，表现出来就是库存变成 0，商品交付类型也被写坏。

这个问题只出现在“编辑 mapped 商品并保存”的场景。

## 改动内容

- 在 `ProductEditModal.vue` 提交商品编辑时，判断当前商品是否为 mapped 商品
- 对于 mapped 商品，不再提交展示用的 `fulfillment_type`
- 让后端继续保留数据库中的真实类型 `upstream`
- 非 mapped 商品保持原有提交流程不变

## 技术细节

- 修复点收敛在 admin 提交层，不改动后端数据结构
- 使用 `editingIsMapped` 作为判断条件
- mapped 商品提交时将 `fulfillment_type` 设为 `undefined`，避免把展示值写回接口
- 后端在缺少该字段时会沿用数据库中已有的真实类型，因此不会再把 `upstream` 覆盖为 `manual/auto`

## 测试情况

- `npm.cmd run build`
- 本地验证 mapped 商品编辑后，其他字段可正常保存
- 本地验证 mapped 商品不会再因保存而改写 `fulfillment_type`
- 本地验证库存展示不会因本次保存操作退化为 0

## 影响范围

仅影响：
- admin 端编辑 mapped 商品时的提交流程
- mapped 商品保存后的交付类型持久化结果

不影响：
- 普通商品编辑流程
- 后端商品结构和库存计算逻辑
- 商品列表和详情页的现有展示逻辑

## 相关说明

这是一个提交层修复，目标是区分“展示用交付类型”和“数据库真实交付类型”。

mapped 商品仍然可以继续按当前方式展示上游实际交付类型，但在保存时不再把这个展示值反写回数据库。
