### PR TITLE
支持商品自选卡密、加价与指定卡密自动发货

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -381,7 +381,7 @@ export const adminAPI = {
   deleteMemberLevelPrice: (id: number) => api.delete<ApiResponse>(`/admin/member-level-prices/${id}`),
   setUserMemberLevel: (userId: number, memberLevelId: number) => api.put<ApiResponse>(`/admin/users/${userId}/member-level`, { member_level_id: memberLevelId }),
   backfillMemberLevels: () => api.post<ApiResponse<{ affected: number }>>('/admin/member-levels/backfill'),
-  createCardSecretBatch: (data: { product_id: number; sku_id?: number; name?: string; secrets: string[]; batch_no?: string; note?: string }) => api.post<ApiResponse<AdminCardSecretBatch>>('/admin/card-secrets/batch', data),
+  createCardSecretBatch: (data: { product_id: number; sku_id?: number; name?: string; secrets: string[]; is_selectable?: boolean; batch_no?: string; note?: string }) => api.post<ApiResponse<AdminCardSecretBatch>>('/admin/card-secrets/batch', data),
   importCardSecretCSV: (formData: FormData) =>
     api.post<ApiResponse>('/admin/card-secrets/import', formData, {
       headers: {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -58,6 +58,8 @@ export interface AdminProduct {
   purchase_type: string
   max_purchase_quantity: number
   fulfillment_type: string
+  enable_secret_selection: boolean
+  secret_selection_markup_amount: number | string
   manual_form_schema: Record<string, unknown> | null
   manual_stock_total: number
   manual_stock_locked: number
@@ -196,6 +198,8 @@ export interface AdminCardSecret {
   product_id: number
   sku_id: number
   batch_id?: number
+  display_secret: string
+  is_selectable: boolean
   secret: string
   status: string
   order_id?: number

--- a/src/views/admin/CardSecrets.vue
+++ b/src/views/admin/CardSecrets.vue
@@ -1067,13 +1067,15 @@ onMounted(async () => {
         </div>
 
         <div class="mt-4 overflow-x-auto">
-          <Table class="min-w-[1320px]">
+          <Table class="min-w-[1480px]">
             <TableHeader class="border-b border-border bg-muted/40 text-xs uppercase text-muted-foreground">
               <TableRow>
                 <TableHead class="px-4 py-3">
                   <input type="checkbox" class="h-4 w-4 accent-primary" :checked="allCurrentPageSelected" @change="toggleSelectAllSecrets" />
                 </TableHead>
                 <TableHead class="px-4 py-3">{{ t('admin.cardSecrets.listTable.id') }}</TableHead>
+                <TableHead class="min-w-[180px] px-4 py-3">展示前缀</TableHead>
+                <TableHead class="min-w-[120px] px-4 py-3">前台可选</TableHead>
                 <TableHead class="min-w-[260px] px-4 py-3">{{ t('admin.cardSecrets.listTable.secret') }}</TableHead>
                 <TableHead class="min-w-[260px] px-4 py-3">{{ t('admin.cardSecrets.listTable.product') }}</TableHead>
                 <TableHead class="min-w-[180px] px-4 py-3">{{ t('admin.cardSecrets.listTable.sku') }}</TableHead>
@@ -1086,12 +1088,12 @@ onMounted(async () => {
             </TableHeader>
             <TableBody class="divide-y divide-border">
               <TableRow v-if="cardSecretsLoading">
-                <TableCell :colspan="10" class="p-0">
-                  <TableSkeleton :columns="10" :rows="5" />
+                <TableCell :colspan="12" class="p-0">
+                  <TableSkeleton :columns="12" :rows="5" />
                 </TableCell>
               </TableRow>
               <TableRow v-else-if="cardSecrets.length === 0">
-                <TableCell colspan="10" class="px-4 py-6 text-center text-muted-foreground">{{ t('admin.cardSecrets.emptyList') }}</TableCell>
+                <TableCell colspan="12" class="px-4 py-6 text-center text-muted-foreground">{{ t('admin.cardSecrets.emptyList') }}</TableCell>
               </TableRow>
               <TableRow v-for="secret in cardSecrets" :key="secret.id" class="hover:bg-muted/30">
                 <TableCell class="px-4 py-3">
@@ -1099,6 +1101,17 @@ onMounted(async () => {
                 </TableCell>
                 <TableCell class="px-4 py-3">
                   <IdCell :value="secret.id" />
+                </TableCell>
+                <TableCell class="min-w-[180px] break-all px-4 py-3 font-mono text-xs text-muted-foreground">
+                  {{ secret.display_secret || '-' }}
+                </TableCell>
+                <TableCell class="min-w-[120px] px-4 py-3 text-xs">
+                  <span
+                    class="inline-flex rounded-full border px-2.5 py-1 text-xs"
+                    :class="secret.is_selectable ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-600'"
+                  >
+                    {{ secret.is_selectable ? '可选' : '关闭' }}
+                  </span>
                 </TableCell>
                 <TableCell class="min-w-[260px] break-all px-4 py-3 font-mono text-xs text-muted-foreground">{{ secret.secret }}</TableCell>
                 <TableCell class="min-w-[260px] px-4 py-3 text-xs text-muted-foreground">

--- a/src/views/admin/components/CardSecretBatchCreateModal.vue
+++ b/src/views/admin/components/CardSecretBatchCreateModal.vue
@@ -23,6 +23,7 @@ const { t } = useI18n()
 // --- Manual batch create ---
 const batchForm = ref({
   secrets: '',
+  is_selectable: false,
   batch_no: '',
   note: '',
 })
@@ -33,6 +34,7 @@ const batchSuccess = ref('')
 // --- CSV import ---
 const importForm = ref({
   file: null as File | null,
+  is_selectable: false,
   batch_no: '',
   note: '',
 })
@@ -44,6 +46,7 @@ const importFileLabel = computed(() => importForm.value.file?.name || t('admin.c
 
 const resetBatchForm = () => {
   batchForm.value.secrets = ''
+  batchForm.value.is_selectable = false
   batchForm.value.batch_no = ''
   batchForm.value.note = ''
   batchError.value = ''
@@ -76,6 +79,7 @@ const handleBatchCreate = async () => {
       product_id: props.productId,
       sku_id: props.skuId || undefined,
       secrets,
+      is_selectable: batchForm.value.is_selectable,
       batch_no: batchForm.value.batch_no.trim(),
       note: batchForm.value.note.trim(),
     })
@@ -106,6 +110,7 @@ const clearImportFile = () => {
 
 const resetImportForm = () => {
   clearImportFile()
+  importForm.value.is_selectable = false
   importForm.value.batch_no = ''
   importForm.value.note = ''
   importError.value = ''
@@ -136,6 +141,7 @@ const handleImport = async () => {
     if (props.skuId > 0) {
       formData.append('sku_id', String(props.skuId))
     }
+    formData.append('is_selectable', String(importForm.value.is_selectable))
     formData.append('batch_no', importForm.value.batch_no.trim())
     formData.append('note', importForm.value.note.trim())
     formData.append('file', importForm.value.file)
@@ -159,8 +165,19 @@ const handleImport = async () => {
       <form class="space-y-4" @submit.prevent="handleBatchCreate">
         <div>
           <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('admin.cardSecrets.secretsLabel') }} *</label>
-          <Textarea v-model="batchForm.secrets" rows="6" :placeholder="t('admin.cardSecrets.secretsPlaceholder')" />
+          <Textarea
+            v-model="batchForm.secrets"
+            rows="6"
+            :placeholder="batchForm.is_selectable ? '一行一个，例如：T12345---12344' : t('admin.cardSecrets.secretsPlaceholder')"
+          />
         </div>
+        <label class="flex items-start gap-3 rounded-lg border border-border bg-muted/20 px-3 py-3 text-sm text-foreground">
+          <input v-model="batchForm.is_selectable" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-input" />
+          <span>
+            <span class="block font-medium">作为自选卡密导入</span>
+            <span class="block text-xs text-muted-foreground">格式必须是 `TXXXXX---12344`，系统只展示前缀 `TXXXXX`，实际自动发货仍发送完整卡密。</span>
+          </span>
+        </label>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('admin.cardSecrets.batchNoLabel') }}</label>
@@ -200,6 +217,13 @@ const handleImport = async () => {
           <input ref="fileInput" type="file" accept=".csv" class="hidden" @change="handleFileChange" />
           <p class="mt-2 text-xs text-muted-foreground">{{ t('admin.cardSecrets.csvHint') }}</p>
         </div>
+        <label class="flex items-start gap-3 rounded-lg border border-border bg-muted/20 px-3 py-3 text-sm text-foreground">
+          <input v-model="importForm.is_selectable" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-input" />
+          <span>
+            <span class="block font-medium">CSV 作为自选卡密导入</span>
+            <span class="block text-xs text-muted-foreground">CSV 的 `secret` 列也必须是 `TXXXXX---12344` 格式，系统只展示前缀，自动发货发送完整卡密。</span>
+          </span>
+        </label>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('admin.cardSecrets.batchNoLabel') }}</label>

--- a/src/views/admin/components/CardSecretEditModal.vue
+++ b/src/views/admin/components/CardSecretEditModal.vue
@@ -5,6 +5,7 @@ import { adminAPI } from '@/api/admin'
 import type { AdminCardSecret } from '@/api/types'
 import IdCell from '@/components/IdCell.vue'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Dialog, DialogScrollContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -26,6 +27,8 @@ const editError = ref('')
 const editForm = reactive({
   id: 0,
   secret: '',
+  display_secret: '',
+  is_selectable: false,
   status: 'available',
 })
 
@@ -35,6 +38,8 @@ watch(
     if (secret) {
       editForm.id = secret.id
       editForm.secret = secret.secret || ''
+      editForm.display_secret = secret.display_secret || ''
+      editForm.is_selectable = Boolean(secret.is_selectable)
       editForm.status = secret.status || 'available'
       editError.value = ''
     }
@@ -57,6 +62,8 @@ const submitEdit = async () => {
   try {
     await adminAPI.updateCardSecret(editForm.id, {
       secret: editForm.secret,
+      display_secret: editForm.display_secret,
+      is_selectable: editForm.is_selectable,
       status: editForm.status,
     })
     closeModal()
@@ -84,6 +91,21 @@ const submitEdit = async () => {
         <div>
           <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('admin.cardSecrets.editSecret') }}</label>
           <Textarea v-model="editForm.secret" rows="3" :placeholder="t('admin.cardSecrets.editSecretPlaceholder')" />
+        </div>
+        <label class="flex items-start gap-3 rounded-lg border border-border bg-muted/20 px-3 py-3 text-sm text-foreground">
+          <input v-model="editForm.is_selectable" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-input" />
+          <span>
+            <span class="block font-medium">允许前台自选</span>
+            <span class="block text-xs text-muted-foreground">关闭后不会出现在自选列表里，开启后建议填写展示前缀，例如 `T12345`。</span>
+          </span>
+        </label>
+        <div>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">展示前缀</label>
+          <Input
+            v-model="editForm.display_secret"
+            placeholder="例如：T12345"
+            :disabled="!editForm.is_selectable"
+          />
         </div>
         <div>
           <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('admin.cardSecrets.editStatus') }}</label>

--- a/src/views/admin/components/ProductEditModal.vue
+++ b/src/views/admin/components/ProductEditModal.vue
@@ -149,6 +149,8 @@ const form = reactive({
   purchase_type: 'member',
   max_purchase_quantity: '' as number | '',
   fulfillment_type: 'manual',
+  enable_secret_selection: false,
+  secret_selection_markup_amount: 0,
   manual_stock_total: 0,
   skus: [] as SKUFormItem[],
   category_id: null as number | null,
@@ -447,6 +449,8 @@ const resetForm = () => {
     purchase_type: 'member',
     max_purchase_quantity: '',
     fulfillment_type: 'manual',
+    enable_secret_selection: false,
+    secret_selection_markup_amount: 0,
     manual_stock_total: 0,
     skus: [],
     category_id: null,
@@ -491,6 +495,8 @@ const populateForm = (product: AdminProduct) => {
     purchase_type: product.purchase_type || 'member',
     max_purchase_quantity: Number(product.max_purchase_quantity || 0) > 0 ? Math.floor(Number(product.max_purchase_quantity || 0)) : '',
     fulfillment_type: product.fulfillment_type || 'manual',
+    enable_secret_selection: Boolean(product.enable_secret_selection),
+    secret_selection_markup_amount: Math.max(Number(product.secret_selection_markup_amount || 0), 0),
     manual_stock_total: resolveManualStockMetrics(product).total,
     skus: Array.isArray(product.skus) ? product.skus.map((item: AdminProductSKU) => createSKUFormItem(item)) : [],
     category_id: Number(product.category_id || 0) || null,
@@ -537,6 +543,10 @@ const handleSubmit = async () => {
       : toSafeStockTotal(form.manual_stock_total)
 
     const payload = {
+      enable_secret_selection: form.fulfillment_type === 'auto' ? Boolean(form.enable_secret_selection) : false,
+      secret_selection_markup_amount: form.fulfillment_type === 'auto'
+        ? Math.max(Number(form.secret_selection_markup_amount || 0), 0)
+        : 0,
       slug: String(form.slug || '').trim(),
       category_id: Math.floor(normalizedCategoryID),
       seo_meta: form.seo_meta,
@@ -780,6 +790,36 @@ watch(
               </SelectContent>
             </Select>
             <p v-if="editingIsMapped" class="mt-1 text-xs text-indigo-600">{{ t('admin.products.mappedFulfillmentLocked') }}</p>
+          </div>
+
+          <div v-if="form.fulfillment_type === 'auto' && !editingIsMapped" class="col-span-1">
+            <label class="block text-xs font-medium text-muted-foreground mb-1.5">自选卡密</label>
+            <Select
+              :model-value="form.enable_secret_selection ? 'true' : 'false'"
+              @update:modelValue="(value) => { form.enable_secret_selection = value === 'true' }"
+            >
+              <SelectTrigger class="h-9 w-full">
+                <SelectValue placeholder="关闭" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="false">关闭</SelectItem>
+                <SelectItem value="true">开启</SelectItem>
+              </SelectContent>
+            </Select>
+            <p class="mt-1 text-xs text-muted-foreground">开启后，前台只显示 `TXXXXX` 这段前缀供用户自选，实际自动发货仍发送完整卡密。同一商品不能混用自选卡密和普通卡密库存。</p>
+          </div>
+
+          <div v-if="form.fulfillment_type === 'auto' && !editingIsMapped" class="col-span-1">
+            <label class="block text-xs font-medium text-muted-foreground mb-1.5">自选加价</label>
+            <Input
+              v-model.number="form.secret_selection_markup_amount"
+              type="number"
+              min="0"
+              step="0.01"
+              placeholder="0.00"
+              :disabled="!form.enable_secret_selection"
+            />
+            <p class="mt-1 text-xs text-muted-foreground">按每个已选卡密加价。用户不选卡密时不加价。</p>
           </div>
 
           <div class="col-span-1">


### PR DESCRIPTION
后台支持自选卡密开关、加价和卡密前缀管理

## 改动说明

本次为自动发货商品增加“自选卡密”能力，用户前台可按卡密前缀进行选择，下单后系统按所选卡密自动发货完整卡密。

## 主要内容

- 商品新增自选卡密开关
- 商品新增自选卡密加价字段
- 卡密新增展示前缀字段 `display_secret`
- 卡密新增是否可自选字段 `is_selectable`
- 前台新增可选卡密列表接口
- 下单接口支持 `selected_secret_ids`
- 订单创建时按选中的卡密精确占用库存
- 自动发货时按选中的卡密精确发货
- 禁止同一商品混用自选卡密和普通卡密库存

## 规则说明

- 前台只展示卡密前缀，例如 `TXXXXX`
- 实际自动发货发送完整卡密，例如 `TXXXXX---12344`
- 自选卡密导入格式为 `TXXXXX---12344`
- 同一商品存在普通卡密库存时，不允许再导入自选卡密；反之亦然

## 验证情况

- `go test ./internal/service ./internal/http/handlers/admin ./internal/http/handlers/public ./internal/router` 通过
