### PR TITLE
fix(order): 后台订单详情按人工交付字段配置顺序展示

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -111,6 +111,7 @@ export interface AdminOrderItem {
   promotion_id?: number
   promotion_name?: string
   tags?: string[]
+  manual_form_schema_snapshot?: Record<string, unknown>
   manual_form_submission?: Record<string, unknown>
   manual_form_schema_snapshot?: Record<string, unknown>
   coupon_discount_amount?: number

--- a/src/views/admin/components/OrderDetailDialog.vue
+++ b/src/views/admin/components/OrderDetailDialog.vue
@@ -157,24 +157,64 @@ const formatManualValue = (value: unknown) => {
   return String(value)
 }
 
-const manualSubmissionRows = (submission: Record<string, unknown> | null | undefined, schemaSnapshot?: Record<string, unknown> | null) => {
+type ManualFormSnapshotField = {
+  key: string
+  label?: Record<string, unknown> | string
+}
+
+const normalizeManualSnapshotFields = (schemaSnapshot: Record<string, unknown> | null | undefined): ManualFormSnapshotField[] => {
+  if (!schemaSnapshot || typeof schemaSnapshot !== 'object') return []
+  const rawFields = Array.isArray(schemaSnapshot.fields) ? schemaSnapshot.fields : []
+  return rawFields
+    .map((field) => {
+      if (!field || typeof field !== 'object') return null
+      const key = String((field as Record<string, unknown>).key || '').trim()
+      if (!key) return null
+      return {
+        key,
+        label: (field as Record<string, unknown>).label as Record<string, unknown> | string | undefined,
+      } satisfies ManualFormSnapshotField
+    })
+    .filter(Boolean) as ManualFormSnapshotField[]
+}
+
+const resolveManualFieldLabel = (field: ManualFormSnapshotField) => {
+  const localized = getLocalizedText(field.label)
+  if (localized) return String(localized)
+  return field.key
+}
+
+const manualSubmissionRows = (
+  submission: Record<string, unknown> | null | undefined,
+  schemaSnapshot?: Record<string, unknown> | null
+) => {
   if (!submission || typeof submission !== 'object') return []
-  const fields = Array.isArray(schemaSnapshot?.fields) ? (schemaSnapshot!.fields as Record<string, unknown>[]) : []
-  const labelMap = new Map<string, string>()
-  for (const field of fields) {
-    const fieldKey = String(field?.key || '').trim()
-    if (fieldKey) {
-      const label = getLocalizedText(field?.label as Record<string, string> | undefined)
-      if (label) labelMap.set(fieldKey, label)
-    }
-  }
-  return Object.entries(submission)
-    .filter(([key]) => String(key).trim() !== '')
-    .map(([key, value]) => ({
-      key: String(key),
-      label: labelMap.get(String(key)) || String(key),
+
+  const entries = Object.entries(submission).filter(([key]) => String(key).trim() !== '')
+  if (entries.length === 0) return []
+
+  const valueMap = new Map(entries.map(([key, value]) => [String(key), value] as const))
+  const rows: Array<{ key: string; label: string; value: string }> = []
+
+  normalizeManualSnapshotFields(schemaSnapshot).forEach((field) => {
+    if (!valueMap.has(field.key)) return
+    rows.push({
+      key: field.key,
+      label: resolveManualFieldLabel(field),
+      value: formatManualValue(valueMap.get(field.key)),
+    })
+    valueMap.delete(field.key)
+  })
+
+  valueMap.forEach((value, key) => {
+    rows.push({
+      key,
+      label: key,
       value: formatManualValue(value),
-    }))
+    })
+  })
+
+  return rows
 }
 
 const parseOrderItemSkuId = (item: AdminOrderItem & Record<string, unknown>) => {


### PR DESCRIPTION
﻿## 背景

issue #90 反馈人工交付字段在后台订单详情中的展示顺序与配置顺序不一致。

当前展示逻辑直接遍历 `manual_form_submission`（对象），会导致：
- 字段顺序不稳定（例如配置为 `username -> password`，展示成 `password -> username`）
- 展示名称只能显示字段 key，无法优先展示配置中的字段名称（label）

## 本次改动

- 调整后台订单详情页人工交付展示逻辑：
  - 优先按 `manual_form_schema_snapshot.fields` 的顺序生成展示行
  - 字段名称优先显示 `label`（多语言文本），无 `label` 时回退到 `key`
  - schema 中不存在但 submission 里存在的字段，仍会追加展示（避免信息丢失）
- 保留旧数据回退逻辑：
  - 当订单项缺少 `manual_form_schema_snapshot` 时，回退到原有 submission 遍历展示
- 补充 admin 端类型声明：
  - `AdminOrderItem` 增加 `manual_form_schema_snapshot` 字段定义

## 兼容性

- 不改数据库结构
- 不改下单/校验链路
- 不改 API 行为
- 仅影响后台订单详情页展示逻辑

## 验证

- `npm.cmd run build`（dujiao-next-admin）通过
- 人工交付场景验证：
  - 配置字段顺序 `username -> password`
  - 下单后后台订单详情展示顺序与配置一致
  - 字段名称优先显示 `label`，无 `label` 时回退 `key`

## 刻意未做

- 未调整后端 manual form 存储结构
- 未改动订单创建和人工表单校验逻辑
- 未改动其他非订单详情页展示组件

## 关联

- user PR: dujiao-next/user#16
- admin PR: dujiao-next/admin#22
- issue: https://github.com/dujiao-next/dujiao-next/issues/90
