### PR TITLE
feat: 后台插件中心与在线授权页面

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -465,4 +465,51 @@ export const adminAPI = {
     api.get(`/admin/ads/render/${slotCode}`, { params }),
   reportAdImpression: (data: { tenant: string; client: string; slot_code: string; items: { ad_id: number; impression_token: string }[] }) =>
     api.post('/admin/ads/impression', data),
+
+  // 插件中心
+  getPlugins: (params?: Record<string, unknown>) => api.get('/admin/plugins', { params }),
+  getPluginRuntimePages: (params?: Record<string, unknown>) => api.get('/admin/plugins/runtime-pages', { params }),
+  uploadPlugin: (formData: FormData) => api.post('/admin/plugins/upload', formData),
+  getPlugin: (id: string) => api.get(`/admin/plugins/${encodeURIComponent(id)}`),
+  installPlugin: (id: string, data?: { version?: string }) => api.post(`/admin/plugins/${encodeURIComponent(id)}/install`, data || {}),
+  enablePlugin: (id: string, data?: { version?: string }) => api.post(`/admin/plugins/${encodeURIComponent(id)}/enable`, data || {}),
+  disablePlugin: (id: string) => api.post(`/admin/plugins/${encodeURIComponent(id)}/disable`),
+  applyPluginRuntimeChanges: () => api.post('/admin/plugins/restart-apply'),
+  reloadPluginRuntime: (id: string) => api.post(`/admin/plugins/${encodeURIComponent(id)}/restart-apply`),
+  rollbackPlugin: (id: string) => api.post(`/admin/plugins/${encodeURIComponent(id)}/rollback`),
+  deletePlugin: (id: string, params?: { purge?: boolean }) => api.delete(`/admin/plugins/${encodeURIComponent(id)}`, { params }),
+  getPluginLogs: (id: string, params?: Record<string, unknown>) => api.get(`/admin/plugins/${encodeURIComponent(id)}/logs`, { params }),
+  getPluginConfig: (id: string) => api.get(`/admin/plugins/${encodeURIComponent(id)}/config`),
+  updatePluginConfig: (id: string, data: Record<string, unknown>) => api.put(`/admin/plugins/${encodeURIComponent(id)}/config`, data),
+
+  // 在线插件库
+  getPluginRegistries: () => api.get('/admin/plugin-market/registries'),
+  refreshPluginMarket: () => api.post('/admin/plugin-market/refresh'),
+  getPluginMarketItems: (params?: Record<string, unknown>) => api.get('/admin/plugin-market/plugins', { params }),
+  getPluginMarketItem: (pluginID: string, params?: Record<string, unknown>) => api.get(`/admin/plugin-market/plugins/${encodeURIComponent(pluginID)}`, { params }),
+  getPluginMarketVersions: (pluginID: string, params?: Record<string, unknown>) => api.get(`/admin/plugin-market/plugins/${encodeURIComponent(pluginID)}/versions`, { params }),
+  installPluginMarketItem: (pluginID: string, data: { registry_id: string; version?: string }) => api.post(`/admin/plugin-market/plugins/${encodeURIComponent(pluginID)}/install`, data),
+
+  // 在线插件中心
+  getPluginMarketCenterPublishers: () => api.get('/admin/plugin-market-center/publishers'),
+  createPluginMarketCenterPublisher: (data: Record<string, unknown>) => api.post('/admin/plugin-market-center/publishers', data),
+  updatePluginMarketCenterPublisher: (id: number, data: Record<string, unknown>) => api.put(`/admin/plugin-market-center/publishers/${id}`, data),
+  deletePluginMarketCenterPublisher: (id: number) => api.delete(`/admin/plugin-market-center/publishers/${id}`),
+  getPluginMarketCenterPlugins: (params?: Record<string, unknown>) => api.get('/admin/plugin-market-center/plugins', { params }),
+  getPluginMarketCenterPlugin: (pluginID: string) => api.get(`/admin/plugin-market-center/plugins/${encodeURIComponent(pluginID)}`),
+  createPluginMarketCenterPlugin: (data: Record<string, unknown>) => api.post('/admin/plugin-market-center/plugins', data),
+  updatePluginMarketCenterPlugin: (pluginID: string, data: Record<string, unknown>) => api.put(`/admin/plugin-market-center/plugins/${encodeURIComponent(pluginID)}`, data),
+  deletePluginMarketCenterPlugin: (pluginID: string) => api.delete(`/admin/plugin-market-center/plugins/${encodeURIComponent(pluginID)}`),
+  createPluginMarketCenterVersion: (pluginID: string, data: Record<string, unknown>) => api.post(`/admin/plugin-market-center/plugins/${encodeURIComponent(pluginID)}/versions`, data),
+  updatePluginMarketCenterVersion: (id: number, data: Record<string, unknown>) => api.put(`/admin/plugin-market-center/versions/${id}`, data),
+  deletePluginMarketCenterVersion: (id: number) => api.delete(`/admin/plugin-market-center/versions/${id}`),
+  createPluginMarketCenterPlan: (pluginID: string, data: Record<string, unknown>) => api.post(`/admin/plugin-market-center/plugins/${encodeURIComponent(pluginID)}/plans`, data),
+  updatePluginMarketCenterPlan: (id: number, data: Record<string, unknown>) => api.put(`/admin/plugin-market-center/plans/${id}`, data),
+  deletePluginMarketCenterPlan: (id: number) => api.delete(`/admin/plugin-market-center/plans/${id}`),
+
+  // 在线授权中心
+  getPluginLicenseCenterLicenses: (params?: Record<string, unknown>) => api.get('/admin/plugin-license-center/licenses', { params }),
+  getPluginLicenseCenterLicense: (licenseID: string) => api.get(`/admin/plugin-license-center/licenses/${encodeURIComponent(licenseID)}`),
+  createPluginLicenseCenterLicense: (data: Record<string, unknown>) => api.post('/admin/plugin-license-center/licenses', data),
+  updatePluginLicenseCenterLicense: (licenseID: string, data: Record<string, unknown>) => api.put(`/admin/plugin-license-center/licenses/${encodeURIComponent(licenseID)}`, data),
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -761,3 +761,308 @@ export interface AdminAffiliateWithdraw {
   user_email?: string
   affiliate_profile?: { id: number; user_id: number; code: string; user_email?: string; user_display_name?: string; user?: { id: number; email: string; display_name?: string } }
 }
+
+// --- Plugin Center ---
+export interface AdminPlugin {
+  id: string
+  name: string
+  type: string
+  author: string
+  summary: string
+  description: string
+  icon: string
+  cover: string
+  source: string
+  status: string
+  review_status: string
+  current_version: string
+  pending_version: string
+  host_api_version: string
+  go_version: string
+  build_target: string
+  entry_symbol: string
+  permissions: string[]
+  config_schema: Record<string, unknown>
+  meta: Record<string, unknown>
+  is_enabled: boolean
+  needs_restart: boolean
+  last_loaded_at?: string
+  last_error?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminPluginVersion {
+  id: number
+  plugin_id: string
+  version: string
+  status: string
+  package_path: string
+  install_path: string
+  checksum: string
+  manifest: Record<string, unknown>
+  meta: Record<string, unknown>
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminPluginRuntimeLog {
+  id: number
+  plugin_id: string
+  plugin_version: string
+  level: string
+  event_type: string
+  message: string
+  details: Record<string, unknown>
+  created_at: string
+}
+
+export interface AdminPluginRouteRegistry {
+  id: number
+  plugin_id: string
+  scope: string
+  path: string
+  methods: string[]
+  meta: Record<string, unknown>
+  created_at: string
+}
+
+export interface AdminPluginPageRegistry {
+  id: number
+  plugin_id: string
+  scope: string
+  route_path: string
+  title: string
+  sort_order: number
+  meta: Record<string, unknown>
+  created_at: string
+}
+
+export interface AdminPluginEventSubscription {
+  id: number
+  plugin_id: string
+  event_type: string
+  meta: Record<string, unknown>
+  created_at: string
+}
+
+export interface AdminPluginDetail {
+  plugin: AdminPlugin
+  versions: AdminPluginVersion[]
+  routes: AdminPluginRouteRegistry[]
+  pages: AdminPluginPageRegistry[]
+  events: AdminPluginEventSubscription[]
+  runtime_loaded: boolean
+  config: Record<string, unknown>
+}
+
+export interface AdminPluginRegistry {
+  id: string
+  name: string
+  description: string
+  source_type: string
+  index_url: string
+  is_built_in: boolean
+  is_enabled: boolean
+  sort_order: number
+  last_sync_at?: string
+  last_sync_status: string
+  last_sync_message: string
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminPluginMarketItem {
+  id: number
+  registry_id: string
+  plugin_id: string
+  version: string
+  name: string
+  author: string
+  type: string
+  summary: string
+  description: string
+  icon: string
+  cover: string
+  host_api_version: string
+  go_version: string
+  build_target: string
+  permissions: string[]
+  download_url: string
+  checksum: string
+  review_status: string
+  changelog: string
+  config_schema: Record<string, unknown>
+  meta: Record<string, unknown>
+  synced_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminOnlinePluginPublisher {
+  id: number
+  publisher_code: string
+  name: string
+  contact_email: string
+  status: string
+  is_official: boolean
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminOnlinePluginCatalogPlugin {
+  id: number
+  plugin_id: string
+  slug: string
+  publisher_id: number
+  name: string
+  summary: string
+  description: string
+  plugin_type: string
+  billing_mode: string
+  license_mode: string
+  status: string
+  is_official: boolean
+  is_public: boolean
+  icon_url: string
+  cover_url: string
+  homepage_url: string
+  source_url: string
+  tags: string[]
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminOnlinePluginVersion {
+  id: number
+  plugin_id: string
+  version: string
+  release_channel: string
+  package_storage_key: string
+  package_download_url: string
+  checksum_sha256: string
+  package_size_bytes: number
+  host_api_version: string
+  build_target: string
+  go_version: string
+  permissions: string[]
+  config_schema: Record<string, unknown>
+  changelog_md: string
+  review_status: string
+  published_at?: string
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminOnlinePluginPlan {
+  id: number
+  plugin_id: string
+  plan_code: string
+  plan_name: string
+  billing_mode: string
+  license_mode: string
+  price_amount: string
+  price_currency: string
+  duration_days?: number
+  max_sites: number
+  max_activations: number
+  feature_flags: Record<string, unknown>
+  status: string
+  sort_order: number
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminOnlinePluginSummary {
+  plugin: AdminOnlinePluginCatalogPlugin
+  publisher?: AdminOnlinePluginPublisher
+  latest_version?: AdminOnlinePluginVersion
+}
+
+export interface AdminOnlinePluginDetail {
+  plugin: AdminOnlinePluginCatalogPlugin
+  publisher?: AdminOnlinePluginPublisher
+  versions: AdminOnlinePluginVersion[]
+  plans: AdminOnlinePluginPlan[]
+  latest_version?: AdminOnlinePluginVersion
+}
+
+export interface AdminPluginLicense {
+  id: number
+  license_id: string
+  plugin_id: string
+  plan_id: number
+  customer_id: number
+  order_id: number
+  license_key: string
+  license_mode: string
+  status: string
+  bound_domain: string
+  bound_server_ip: string
+  expire_at?: string
+  grace_deadline_at?: string
+  feature_flags: Record<string, unknown>
+  activation_secret_hash: string
+  issued_at: string
+  activated_at?: string
+  last_validated_at?: string
+  meta: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminPluginLicenseActivation {
+  id: number
+  license_id: string
+  site_id: string
+  install_id: string
+  host_fingerprint: string
+  reported_domain: string
+  reported_ip: string
+  validated_domain: string
+  validated_server_ip: string
+  activation_token: string
+  status: string
+  activated_at: string
+  last_heartbeat_at?: string
+  last_seen_at?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface AdminPluginLicenseHeartbeat {
+  id: number
+  license_id: string
+  activation_id: number
+  reported_domain: string
+  reported_ip: string
+  reported_version: string
+  runtime_loaded: boolean
+  matched_domain: boolean
+  matched_server_ip: boolean
+  license_status: string
+  enforcement_action: string
+  message: string
+  created_at: string
+}
+
+export interface AdminPluginLicenseSummary {
+  license: AdminPluginLicense
+  plugin?: AdminOnlinePluginCatalogPlugin
+  plan?: AdminOnlinePluginPlan
+  active_activation?: AdminPluginLicenseActivation
+}
+
+export interface AdminPluginLicenseDetail {
+  license: AdminPluginLicense
+  plugin?: AdminOnlinePluginCatalogPlugin
+  plan?: AdminOnlinePluginPlan
+  activations: AdminPluginLicenseActivation[]
+  recent_heartbeats: AdminPluginLicenseHeartbeat[]
+}

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -43,15 +43,19 @@ import {
   Crown,
   Bell,
   ImageIcon,
+  Layers3,
 } from 'lucide-vue-next'
 import { Menu } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import type { AdminPluginPageRegistry } from '@/api/types'
 import { useAdminAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
 import { adminAPI } from '@/api/admin'
+import { loadMountedAdminPluginPages } from '@/utils/plugin-runtime-pages'
+import { buildPluginAdminNavGroups } from '@/utils/plugin-admin-pages'
 
 interface NavGroupItem {
   label: string
@@ -106,6 +110,7 @@ const expandedGroups = ref<Record<string, boolean>>(readExpandedGroups())
 const mobileNavOpen = ref(false)
 const sidebarCollapsed = ref(false)
 const sidebarUserToggled = ref(false) // tracks if user manually toggled
+const mountedAdminPages = ref<AdminPluginPageRegistry[]>([])
 
 // Close mobile nav on route change
 watch(() => route.path, () => {
@@ -382,6 +387,37 @@ const navGroups = computed<NavGroup[]>(() => {
       ],
     },
     {
+      id: 'plugins',
+      label: '插件中心',
+      icon: Layers3,
+      items: [
+        {
+          label: '已安装插件',
+          to: '/plugins',
+          icon: Layers3,
+          permission: 'GET:/admin/plugins',
+        },
+        {
+          label: '在线插件库',
+          to: '/plugin-market',
+          icon: Link,
+          permission: 'GET:/admin/plugin-market/registries',
+        },
+        {
+          label: '在线插件中心',
+          to: '/plugin-market-center',
+          icon: Link,
+          permission: 'GET:/admin/plugin-market-center/publishers',
+        },
+        {
+          label: '在线授权中心',
+          to: '/plugin-license-center',
+          icon: KeyRound,
+          permission: 'GET:/admin/plugin-license-center/licenses',
+        },
+      ],
+    },
+    {
       id: 'system',
       label: t('admin.navGroups.systemSettings'),
       icon: Settings,
@@ -419,6 +455,16 @@ const navGroups = computed<NavGroup[]>(() => {
     },
   ]
 
+  groups.splice(
+    Math.max(groups.length - 1, 0),
+    0,
+    ...buildPluginAdminNavGroups(
+      mountedAdminPages.value,
+      t,
+      (permission?: string) => authStore.hasPermission(permission),
+    ),
+  )
+
   return groups
     .map((group) => ({
       ...group,
@@ -426,6 +472,14 @@ const navGroups = computed<NavGroup[]>(() => {
     }))
     .filter((group) => group.items.length > 0)
 })
+
+const refreshMountedAdminPages = async (force = false) => {
+  mountedAdminPages.value = await loadMountedAdminPluginPages(force)
+}
+
+const handlePluginRuntimePagesChanged = () => {
+  refreshMountedAdminPages(true)
+}
 
 watch(
   navGroups,
@@ -579,10 +633,13 @@ onMounted(() => {
       appVersion.value = ver
     }
   }).catch(() => {})
+  refreshMountedAdminPages()
+  window.addEventListener('admin-plugin-runtime-pages-changed', handlePluginRuntimePagesChanged)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('resize', handleResize)
+  window.removeEventListener('admin-plugin-runtime-pages-changed', handlePluginRuntimePagesChanged)
 })
 </script>
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAdminAuthStore } from '@/stores/auth'
+import { hasMountedAdminPluginPage, loadMountedAdminPluginPages } from '@/utils/plugin-runtime-pages'
+import { syncMountedAdminPluginRoutes } from '@/utils/plugin-admin-pages'
 
 const routes = [
   {
@@ -274,6 +276,30 @@ const routes = [
         component: () => import('@/views/admin/TelegramBotBroadcastDetail.vue'),
         meta: { permission: 'GET:/admin/telegram-bot/broadcasts' },
       },
+      {
+        path: 'plugins',
+        name: 'plugins',
+        component: () => import('@/views/admin/Plugins.vue'),
+        meta: { permission: 'GET:/admin/plugins' },
+      },
+      {
+        path: 'plugin-market',
+        name: 'plugin-market',
+        component: () => import('@/views/admin/PluginMarket.vue'),
+        meta: { permission: 'GET:/admin/plugin-market/registries' },
+      },
+      {
+        path: 'plugin-market-center',
+        name: 'plugin-market-center',
+        component: () => import('@/views/admin/PluginMarketCenter.vue'),
+        meta: { permission: 'GET:/admin/plugin-market-center/publishers' },
+      },
+      {
+        path: 'plugin-license-center',
+        name: 'plugin-license-center',
+        component: () => import('@/views/admin/PluginLicenseCenter.vue'),
+        meta: { permission: 'GET:/admin/plugin-license-center/licenses' },
+      },
     ],
   },
 ]
@@ -285,8 +311,9 @@ const router = createRouter({
 
 router.beforeEach(async (to) => {
   const authStore = useAdminAuthStore()
+  const requiresAuth = to.path !== '/login'
 
-  if (to.meta.requiresAuth && !authStore.token) {
+  if (requiresAuth && !authStore.token) {
     return { path: '/login' }
   }
 
@@ -294,12 +321,32 @@ router.beforeEach(async (to) => {
     return { path: '/' }
   }
 
-  if (to.meta.requiresAuth && authStore.token && !authStore.permissionsLoaded) {
+  if (requiresAuth && authStore.token && !authStore.permissionsLoaded) {
     try {
       await authStore.loadAuthz()
     } catch {
       authStore.logout()
       return { path: '/login' }
+    }
+  }
+
+  let mountedPages = [] as Awaited<ReturnType<typeof loadMountedAdminPluginPages>>
+  if (requiresAuth && authStore.token) {
+    mountedPages = await syncMountedAdminPluginRoutes(router)
+    if (to.matched.length === 0) {
+      const resolved = router.resolve({
+        path: to.path,
+        query: to.query,
+        hash: to.hash,
+      })
+      if (resolved.matched.length > 0) {
+        return {
+          path: to.path,
+          query: to.query,
+          hash: to.hash,
+          replace: true,
+        }
+      }
     }
   }
 
@@ -311,6 +358,22 @@ router.beforeEach(async (to) => {
         query: {
           from: to.fullPath,
         },
+      }
+    }
+  }
+
+  const requiredPluginPage = typeof to.meta.pluginPagePath === 'string' ? to.meta.pluginPagePath : ''
+  if (requiredPluginPage) {
+    const currentMountedPages = mountedPages.length > 0 ? mountedPages : await loadMountedAdminPluginPages()
+    if (!hasMountedAdminPluginPage(requiredPluginPage, currentMountedPages)) {
+      if (to.path !== '/forbidden') {
+        return {
+          path: '/forbidden',
+          query: {
+            from: to.fullPath,
+            reason: 'plugin_page_unavailable',
+          },
+        }
       }
     }
   }

--- a/src/utils/plugin-admin-pages.ts
+++ b/src/utils/plugin-admin-pages.ts
@@ -1,0 +1,226 @@
+import { KeyRound, Layers3, ListOrdered, ScrollText } from 'lucide-vue-next'
+import type { RouteRecordRaw, Router } from 'vue-router'
+
+import type { AdminPluginPageRegistry } from '@/api/types'
+
+import { loadMountedAdminPluginPages } from './plugin-runtime-pages'
+
+export interface PluginAdminNavItem {
+  label: string
+  to: string
+  permission?: string
+  icon?: any
+}
+
+export interface PluginAdminNavGroup {
+  id: string
+  label: string
+  icon: any
+  items: PluginAdminNavItem[]
+  sortOrder: number
+}
+
+interface PluginAdminPageMeta {
+  routeName: string
+  viewKey: string
+  permission: string
+  navGroupID: string
+  navGroupLabel: string
+  navGroupLabelI18nKey: string
+  navGroupIconKey: string
+  navGroupSort: number
+  navHidden: boolean
+  navLabel: string
+  navLabelI18nKey: string
+  navIconKey: string
+}
+
+const pluginAdminComponentLoaders: Record<string, () => Promise<any>> = {
+  plugin_runtime_placeholder: () => import('@/views/admin/PluginRuntimePage.vue'),
+}
+
+const iconMap: Record<string, any> = {
+  keyround: KeyRound,
+  layers3: Layers3,
+  listordered: ListOrdered,
+  scrolltext: ScrollText,
+}
+
+let registeredPluginRouteNames = new Set<string>()
+
+const normalizeRoutePath = (value: string) => {
+  const trimmed = value.trim()
+  if (!trimmed) return '/'
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+const normalizeIconKey = (value: string) => value.trim().toLowerCase().replace(/[^a-z0-9]/g, '')
+
+const readObject = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  return value as Record<string, unknown>
+}
+
+const readString = (record: Record<string, unknown>, key: string) => {
+  const value = record[key]
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+const readBool = (record: Record<string, unknown>, key: string) => record[key] === true
+
+const readNumber = (record: Record<string, unknown>, key: string, fallback: number) => {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+const fallbackRouteName = (page: AdminPluginPageRegistry) => {
+  const normalized = normalizeRoutePath(page.route_path)
+    .slice(1)
+    .replace(/[:/]+/g, '-')
+    .replace(/[^a-zA-Z0-9_-]/g, '-')
+  const suffix = normalized || 'root'
+  return `plugin-admin-${page.plugin_id}-${suffix}`
+}
+
+const resolveRouteName = (page: AdminPluginPageRegistry, routeName: string) => {
+  const suffix = routeName || fallbackRouteName(page)
+  return `plugin:${page.plugin_id}:${suffix}`
+}
+
+const resolveIcon = (iconKey: string, fallback: any = Layers3) => {
+  if (!iconKey) {
+    return fallback
+  }
+  return iconMap[normalizeIconKey(iconKey)] || fallback
+}
+
+const resolveText = (i18nKey: string, fallback: string, translate: (key: string) => string) => {
+  if (i18nKey) {
+    const translated = translate(i18nKey)
+    if (translated && translated !== i18nKey) {
+      return translated
+    }
+  }
+  return fallback
+}
+
+export function readPluginAdminPageMeta(page: AdminPluginPageRegistry): PluginAdminPageMeta {
+  const meta = readObject(page.meta)
+  return {
+    routeName: resolveRouteName(page, readString(meta, 'route_name')),
+    viewKey: readString(meta, 'view_key') || 'plugin_runtime_placeholder',
+    permission: readString(meta, 'permission'),
+    navGroupID: readString(meta, 'nav_group_id') || `plugin:${page.plugin_id}`,
+    navGroupLabel: readString(meta, 'nav_group_label') || page.plugin_id,
+    navGroupLabelI18nKey: readString(meta, 'nav_group_label_i18n_key'),
+    navGroupIconKey: readString(meta, 'nav_group_icon'),
+    navGroupSort: readNumber(meta, 'nav_group_sort', 500),
+    navHidden: readBool(meta, 'nav_hidden'),
+    navLabel: readString(meta, 'nav_label') || page.title || normalizeRoutePath(page.route_path),
+    navLabelI18nKey: readString(meta, 'nav_label_i18n_key'),
+    navIconKey: readString(meta, 'nav_icon'),
+  }
+}
+
+function buildPluginAdminRouteRecord(page: AdminPluginPageRegistry): RouteRecordRaw {
+  const pageMeta = readPluginAdminPageMeta(page)
+  const loader = pluginAdminComponentLoaders[pageMeta.viewKey] || pluginAdminComponentLoaders.plugin_runtime_placeholder
+
+  return {
+    path: normalizeRoutePath(page.route_path).slice(1),
+    name: pageMeta.routeName,
+    component: loader,
+    meta: {
+      permission: pageMeta.permission,
+      pluginPagePath: normalizeRoutePath(page.route_path),
+      pluginId: page.plugin_id,
+      pluginTitle: page.title,
+      pluginMeta: page.meta,
+      pluginRuntimePage: true,
+    },
+  } as RouteRecordRaw
+}
+
+export function syncPluginAdminRoutes(router: Router, pages: AdminPluginPageRegistry[]) {
+  const nextRouteNames = new Set<string>()
+  const sortedPages = [...pages].sort((left, right) => {
+    if (left.sort_order !== right.sort_order) {
+      return left.sort_order - right.sort_order
+    }
+    return normalizeRoutePath(left.route_path).localeCompare(normalizeRoutePath(right.route_path))
+  })
+
+  sortedPages.forEach((page) => {
+    const record = buildPluginAdminRouteRecord(page)
+    const routeName = String(record.name)
+    nextRouteNames.add(routeName)
+    if (router.hasRoute(routeName)) {
+      router.removeRoute(routeName)
+    }
+    router.addRoute('dashboard', record)
+  })
+
+  Array.from(registeredPluginRouteNames).forEach((routeName) => {
+    if (!nextRouteNames.has(routeName) && router.hasRoute(routeName)) {
+      router.removeRoute(routeName)
+    }
+  })
+
+  registeredPluginRouteNames = nextRouteNames
+}
+
+export async function syncMountedAdminPluginRoutes(router: Router, force = false) {
+  const pages = await loadMountedAdminPluginPages(force)
+  syncPluginAdminRoutes(router, pages)
+  return pages
+}
+
+export function buildPluginAdminNavGroups(
+  pages: AdminPluginPageRegistry[],
+  translate: (key: string) => string,
+  hasPermission: (permission?: string) => boolean,
+): PluginAdminNavGroup[] {
+  const groupMap = new Map<string, PluginAdminNavGroup>()
+  const sortedPages = [...pages].sort((left, right) => {
+    if (left.sort_order !== right.sort_order) {
+      return left.sort_order - right.sort_order
+    }
+    return normalizeRoutePath(left.route_path).localeCompare(normalizeRoutePath(right.route_path))
+  })
+
+  sortedPages.forEach((page) => {
+    const pageMeta = readPluginAdminPageMeta(page)
+    if (pageMeta.navHidden || !hasPermission(pageMeta.permission)) {
+      return
+    }
+    if (!groupMap.has(pageMeta.navGroupID)) {
+      groupMap.set(pageMeta.navGroupID, {
+        id: pageMeta.navGroupID,
+        label: resolveText(pageMeta.navGroupLabelI18nKey, pageMeta.navGroupLabel, translate),
+        icon: resolveIcon(pageMeta.navGroupIconKey),
+        items: [],
+        sortOrder: pageMeta.navGroupSort,
+      })
+    }
+    const group = groupMap.get(pageMeta.navGroupID)
+    if (!group) {
+      return
+    }
+    group.items.push({
+      label: resolveText(pageMeta.navLabelI18nKey, pageMeta.navLabel, translate),
+      to: normalizeRoutePath(page.route_path),
+      permission: pageMeta.permission,
+      icon: resolveIcon(pageMeta.navIconKey, group.icon),
+    })
+  })
+
+  return Array.from(groupMap.values())
+    .map((group) => ({
+      ...group,
+      items: group.items.sort((left, right) => left.to.localeCompare(right.to)),
+    }))
+    .filter((group) => group.items.length > 0)
+    .sort((left, right) => left.sortOrder - right.sortOrder)
+}

--- a/src/utils/plugin-runtime-pages.ts
+++ b/src/utils/plugin-runtime-pages.ts
@@ -1,0 +1,45 @@
+import { adminAPI } from '@/api/admin'
+import type { AdminPluginPageRegistry } from '@/api/types'
+
+let mountedAdminPagesCache: AdminPluginPageRegistry[] | null = null
+let mountedAdminPagesPromise: Promise<AdminPluginPageRegistry[]> | null = null
+
+const normalizeRoutePath = (value: string) => {
+  const trimmed = value.trim()
+  if (!trimmed) return '/'
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+export function invalidateMountedAdminPluginPages() {
+  mountedAdminPagesCache = null
+  mountedAdminPagesPromise = null
+}
+
+export async function loadMountedAdminPluginPages(force = false): Promise<AdminPluginPageRegistry[]> {
+  if (!force && mountedAdminPagesCache) {
+    return mountedAdminPagesCache
+  }
+  if (!force && mountedAdminPagesPromise) {
+    return mountedAdminPagesPromise
+  }
+  mountedAdminPagesPromise = adminAPI.getPluginRuntimePages({ scope: 'admin' })
+    .then((res: any) => {
+      const data = res.data?.data
+      mountedAdminPagesCache = Array.isArray(data) ? data : []
+      return mountedAdminPagesCache
+    })
+    .catch(() => {
+      mountedAdminPagesCache = []
+      return mountedAdminPagesCache
+    })
+    .finally(() => {
+      mountedAdminPagesPromise = null
+    })
+  return mountedAdminPagesPromise ?? []
+}
+
+export function hasMountedAdminPluginPage(routePath: string, pages?: AdminPluginPageRegistry[]) {
+  const currentPages = pages ?? mountedAdminPagesCache ?? []
+  const normalizedRoutePath = normalizeRoutePath(routePath)
+  return currentPages.some((item) => normalizeRoutePath(item.route_path) === normalizedRoutePath)
+}

--- a/src/views/admin/PluginLicenseCenter.vue
+++ b/src/views/admin/PluginLicenseCenter.vue
@@ -1,0 +1,541 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { adminAPI } from '@/api/admin'
+import type {
+  AdminPluginLicense,
+  AdminPluginLicenseDetail,
+  AdminPluginLicenseSummary,
+} from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import { notifyError, notifySuccess } from '@/utils/notify'
+
+const loading = ref(false)
+const saving = ref(false)
+const detailLoading = ref(false)
+
+const licenses = ref<AdminPluginLicenseSummary[]>([])
+const detail = ref<AdminPluginLicenseDetail | null>(null)
+const selectedLicenseID = ref('')
+const dialogOpen = ref(false)
+const editingLicenseID = ref('')
+const pagination = ref({ page: 1, page_size: 20, total: 0, total_page: 1 })
+
+const filters = reactive({
+  keyword: '',
+  plugin_id: '',
+  status: '__all__',
+  license_mode: '__all__',
+})
+
+const form = reactive({
+  plugin_id: '',
+  plan_code: '',
+  customer_id: '0',
+  order_id: '0',
+  license_id: '',
+  license_key: '',
+  license_mode: 'annual',
+  status: 'pending',
+  bound_domain: '',
+  bound_server_ip: '',
+  expire_at: '',
+  grace_deadline_at: '',
+  feature_flags_text: '{}',
+  meta_text: '{}',
+})
+
+const currentLicense = computed(() => detail.value?.license || null)
+
+const normalizeSelectValue = (value: string) => (value === '__all__' ? '' : value)
+
+const stringifyObject = (value: Record<string, unknown> | undefined) => JSON.stringify(value || {}, null, 2)
+
+const parseObjectText = (text: string, label: string) => {
+  const raw = text.trim()
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${label}必须是 JSON 对象`)
+    }
+    return parsed as Record<string, unknown>
+  } catch (error: any) {
+    throw new Error(error?.message || `${label}解析失败`)
+  }
+}
+
+const formatDate = (value?: string) => (value ? new Date(value).toLocaleString() : '-')
+
+const statusBadgeVariant = (value?: string) => {
+  switch (value) {
+    case 'active':
+      return 'default'
+    case 'grace':
+      return 'secondary'
+    case 'revoked':
+    case 'expired':
+    case 'suspended':
+    case 'mismatch':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+const enforcementBadgeVariant = (value?: string) => {
+  switch (value) {
+    case 'ok':
+      return 'default'
+    case 'warn':
+      return 'secondary'
+    default:
+      return 'destructive'
+  }
+}
+
+const loadLicenses = async (page = 1) => {
+  loading.value = true
+  try {
+    const response = await adminAPI.getPluginLicenseCenterLicenses({
+      page,
+      page_size: pagination.value.page_size,
+      keyword: filters.keyword.trim() || undefined,
+      plugin_id: filters.plugin_id.trim() || undefined,
+      status: normalizeSelectValue(filters.status) || undefined,
+      license_mode: normalizeSelectValue(filters.license_mode) || undefined,
+    })
+    licenses.value = response.data?.data || []
+    pagination.value = response.data?.pagination || pagination.value
+  } catch (error: any) {
+    licenses.value = []
+    notifyError(error?.response?.data?.msg || error?.message || '加载在线授权中心失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const loadDetail = async (licenseID: string) => {
+  if (!licenseID) return
+  detailLoading.value = true
+  selectedLicenseID.value = licenseID
+  try {
+    const response = await adminAPI.getPluginLicenseCenterLicense(licenseID)
+    detail.value = response.data?.data || null
+  } catch (error: any) {
+    detail.value = null
+    notifyError(error?.response?.data?.msg || error?.message || '加载授权详情失败')
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const resetForm = () => {
+  editingLicenseID.value = ''
+  form.plugin_id = ''
+  form.plan_code = ''
+  form.customer_id = '0'
+  form.order_id = '0'
+  form.license_id = ''
+  form.license_key = ''
+  form.license_mode = 'annual'
+  form.status = 'pending'
+  form.bound_domain = ''
+  form.bound_server_ip = ''
+  form.expire_at = ''
+  form.grace_deadline_at = ''
+  form.feature_flags_text = '{}'
+  form.meta_text = '{}'
+}
+
+const fillForm = (item: AdminPluginLicense) => {
+  editingLicenseID.value = item.license_id
+  form.plugin_id = item.plugin_id || ''
+  form.plan_code = detail.value?.plan?.plan_code || ''
+  form.customer_id = String(item.customer_id || 0)
+  form.order_id = String(item.order_id || 0)
+  form.license_id = item.license_id || ''
+  form.license_key = item.license_key || ''
+  form.license_mode = item.license_mode || 'annual'
+  form.status = item.status || 'pending'
+  form.bound_domain = item.bound_domain || ''
+  form.bound_server_ip = item.bound_server_ip || ''
+  form.expire_at = item.expire_at || ''
+  form.grace_deadline_at = item.grace_deadline_at || ''
+  form.feature_flags_text = stringifyObject(item.feature_flags)
+  form.meta_text = stringifyObject(item.meta)
+}
+
+const openCreateDialog = () => {
+  resetForm()
+  dialogOpen.value = true
+}
+
+const openEditDialog = async (licenseID: string) => {
+  if (!licenseID) return
+  if (!detail.value || detail.value.license.license_id !== licenseID) {
+    await loadDetail(licenseID)
+  }
+  if (!detail.value?.license) return
+  resetForm()
+  fillForm(detail.value.license)
+  dialogOpen.value = true
+}
+
+const submitForm = async () => {
+  if (!form.plugin_id.trim()) {
+    notifyError('插件 ID 不能为空')
+    return
+  }
+  saving.value = true
+  try {
+    const payload = {
+      plugin_id: form.plugin_id.trim(),
+      plan_code: form.plan_code.trim() || undefined,
+      customer_id: Number(form.customer_id || '0'),
+      order_id: Number(form.order_id || '0'),
+      license_id: form.license_id.trim() || undefined,
+      license_key: form.license_key.trim() || undefined,
+      license_mode: form.license_mode,
+      status: form.status,
+      bound_domain: form.bound_domain.trim() || undefined,
+      bound_server_ip: form.bound_server_ip.trim() || undefined,
+      expire_at: form.expire_at.trim() || '',
+      grace_deadline_at: form.grace_deadline_at.trim() || '',
+      feature_flags: parseObjectText(form.feature_flags_text, '功能标记'),
+      meta: parseObjectText(form.meta_text, '扩展元数据'),
+    }
+    if (editingLicenseID.value) {
+      await adminAPI.updatePluginLicenseCenterLicense(editingLicenseID.value, payload)
+      notifySuccess('插件授权已更新')
+    } else {
+      await adminAPI.createPluginLicenseCenterLicense(payload)
+      notifySuccess('插件授权已创建')
+    }
+    dialogOpen.value = false
+    await loadLicenses(pagination.value.page)
+    if (selectedLicenseID.value) {
+      await loadDetail(selectedLicenseID.value)
+    }
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '保存插件授权失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const selectLicense = (item: AdminPluginLicenseSummary) => {
+  if (item.license?.license_id) {
+    loadDetail(item.license.license_id)
+  }
+}
+
+onMounted(async () => {
+  await loadLicenses()
+  if (licenses.value[0]?.license?.license_id) {
+    await loadDetail(licenses.value[0].license.license_id)
+  }
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold">在线授权中心</h1>
+        <p class="text-sm text-muted-foreground">管理插件许可证、绑定关系、激活实例与最近心跳。</p>
+      </div>
+      <div class="flex gap-2">
+        <Button variant="outline" @click="loadLicenses(pagination.page)" :disabled="loading">刷新列表</Button>
+        <Button @click="openCreateDialog">新增授权</Button>
+      </div>
+    </div>
+
+    <Card>
+      <CardHeader><CardTitle>授权筛选</CardTitle></CardHeader>
+      <CardContent class="grid gap-3 md:grid-cols-4">
+        <Input v-model="filters.keyword" placeholder="搜索授权 ID / License Key / 插件 ID / 域名" @keyup.enter="loadLicenses()" />
+        <Input v-model="filters.plugin_id" placeholder="插件 ID，如 telegram-suite" @keyup.enter="loadLicenses()" />
+        <Select v-model="filters.status">
+          <SelectTrigger><SelectValue placeholder="全部状态" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部状态</SelectItem>
+            <SelectItem value="pending">pending</SelectItem>
+            <SelectItem value="active">active</SelectItem>
+            <SelectItem value="grace">grace</SelectItem>
+            <SelectItem value="expired">expired</SelectItem>
+            <SelectItem value="revoked">revoked</SelectItem>
+            <SelectItem value="suspended">suspended</SelectItem>
+          </SelectContent>
+        </Select>
+        <div class="flex gap-2">
+          <Select v-model="filters.license_mode">
+            <SelectTrigger><SelectValue placeholder="全部授权模式" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">全部授权模式</SelectItem>
+              <SelectItem value="free">free</SelectItem>
+              <SelectItem value="annual">annual</SelectItem>
+              <SelectItem value="perpetual">perpetual</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button class="shrink-0" @click="loadLicenses()">查询</Button>
+        </div>
+      </CardContent>
+    </Card>
+
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+      <Card>
+        <CardHeader><CardTitle>授权列表</CardTitle></CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>授权</TableHead>
+                <TableHead>插件</TableHead>
+                <TableHead>绑定</TableHead>
+                <TableHead>状态</TableHead>
+                <TableHead>活跃实例</TableHead>
+                <TableHead class="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow v-if="loading">
+                <TableCell colspan="6" class="py-8 text-center text-muted-foreground">正在加载授权列表...</TableCell>
+              </TableRow>
+              <TableRow v-else-if="!licenses.length">
+                <TableCell colspan="6" class="py-8 text-center text-muted-foreground">暂时还没有授权数据</TableCell>
+              </TableRow>
+              <TableRow
+                v-for="item in licenses"
+                :key="item.license.license_id"
+                class="cursor-pointer"
+                :class="selectedLicenseID === item.license.license_id ? 'bg-muted/50' : ''"
+                @click="selectLicense(item)"
+              >
+                <TableCell>
+                  <div class="font-medium">{{ item.license.license_id }}</div>
+                  <div class="text-xs text-muted-foreground break-all">{{ item.license.license_key }}</div>
+                </TableCell>
+                <TableCell>
+                  <div>{{ item.plugin?.name || item.license.plugin_id }}</div>
+                  <div class="text-xs text-muted-foreground">{{ item.plan?.plan_code || '未指定方案' }}</div>
+                </TableCell>
+                <TableCell>
+                  <div class="text-sm">{{ item.license.bound_domain || '-' }}</div>
+                  <div class="text-xs text-muted-foreground">{{ item.license.bound_server_ip || '-' }}</div>
+                </TableCell>
+                <TableCell>
+                  <Badge :variant="statusBadgeVariant(item.license.status)">{{ item.license.status }}</Badge>
+                </TableCell>
+                <TableCell>
+                  <div class="text-sm">{{ item.active_activation?.install_id || '-' }}</div>
+                  <div class="text-xs text-muted-foreground">{{ item.active_activation?.last_heartbeat_at ? formatDate(item.active_activation?.last_heartbeat_at) : '暂无心跳' }}</div>
+                </TableCell>
+                <TableCell class="text-right">
+                  <Button size="sm" variant="outline" @click.stop="openEditDialog(item.license.license_id)">编辑</Button>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+
+          <div class="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+            <span>共 {{ pagination.total }} 条，当前第 {{ pagination.page }} / {{ pagination.total_page || 1 }} 页</span>
+            <div class="flex gap-2">
+              <Button size="sm" variant="outline" :disabled="pagination.page <= 1 || loading" @click="loadLicenses(pagination.page - 1)">上一页</Button>
+              <Button size="sm" variant="outline" :disabled="pagination.page >= pagination.total_page || loading" @click="loadLicenses(pagination.page + 1)">下一页</Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader class="flex flex-row items-center justify-between">
+          <CardTitle>授权详情</CardTitle>
+          <Button v-if="currentLicense" size="sm" variant="outline" @click="openEditDialog(currentLicense.license_id)">编辑当前授权</Button>
+        </CardHeader>
+        <CardContent class="space-y-6">
+          <div v-if="detailLoading" class="py-10 text-center text-muted-foreground">正在加载授权详情...</div>
+          <div v-else-if="!detail?.license" class="py-10 text-center text-muted-foreground">请选择一条授权查看详情</div>
+          <template v-else>
+            <div class="grid gap-3 md:grid-cols-2">
+              <div><span class="text-muted-foreground">授权 ID：</span>{{ detail.license.license_id }}</div>
+              <div><span class="text-muted-foreground">插件：</span>{{ detail.plugin?.name || detail.license.plugin_id }}</div>
+              <div><span class="text-muted-foreground">License Key：</span><span class="break-all">{{ detail.license.license_key }}</span></div>
+              <div><span class="text-muted-foreground">方案：</span>{{ detail.plan?.plan_name || detail.plan?.plan_code || '未指定方案' }}</div>
+              <div><span class="text-muted-foreground">授权模式：</span>{{ detail.license.license_mode }}</div>
+              <div><span class="text-muted-foreground">状态：</span><Badge :variant="statusBadgeVariant(detail.license.status)">{{ detail.license.status }}</Badge></div>
+              <div><span class="text-muted-foreground">绑定域名：</span>{{ detail.license.bound_domain || '-' }}</div>
+              <div><span class="text-muted-foreground">绑定 IP：</span>{{ detail.license.bound_server_ip || '-' }}</div>
+              <div><span class="text-muted-foreground">签发时间：</span>{{ formatDate(detail.license.issued_at) }}</div>
+              <div><span class="text-muted-foreground">激活时间：</span>{{ formatDate(detail.license.activated_at) }}</div>
+              <div><span class="text-muted-foreground">到期时间：</span>{{ formatDate(detail.license.expire_at) }}</div>
+              <div><span class="text-muted-foreground">最近校验：</span>{{ formatDate(detail.license.last_validated_at) }}</div>
+            </div>
+
+            <div class="space-y-3">
+              <div class="text-sm font-medium">功能标记</div>
+              <pre class="overflow-auto rounded-md bg-muted p-3 text-xs">{{ JSON.stringify(detail.license.feature_flags || {}, null, 2) }}</pre>
+            </div>
+
+            <div class="space-y-3">
+              <div class="text-sm font-medium">激活实例</div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>安装实例</TableHead>
+                    <TableHead>状态</TableHead>
+                    <TableHead>绑定确认</TableHead>
+                    <TableHead>最近心跳</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow v-if="!detail.activations.length">
+                    <TableCell colspan="4" class="py-6 text-center text-muted-foreground">暂无激活实例</TableCell>
+                  </TableRow>
+                  <TableRow v-for="item in detail.activations" :key="item.id">
+                    <TableCell>
+                      <div class="font-medium">{{ item.install_id || '-' }}</div>
+                      <div class="text-xs text-muted-foreground">{{ item.reported_domain || '-' }} / {{ item.reported_ip || '-' }}</div>
+                    </TableCell>
+                    <TableCell><Badge :variant="statusBadgeVariant(item.status)">{{ item.status }}</Badge></TableCell>
+                    <TableCell>
+                      <div>{{ item.validated_domain || '-' }}</div>
+                      <div class="text-xs text-muted-foreground">{{ item.validated_server_ip || '-' }}</div>
+                    </TableCell>
+                    <TableCell>{{ formatDate(item.last_heartbeat_at || item.last_seen_at) }}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </div>
+
+            <div class="space-y-3">
+              <div class="text-sm font-medium">最近心跳</div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>时间</TableHead>
+                    <TableHead>上报</TableHead>
+                    <TableHead>判定</TableHead>
+                    <TableHead>动作</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow v-if="!detail.recent_heartbeats.length">
+                    <TableCell colspan="4" class="py-6 text-center text-muted-foreground">暂无心跳记录</TableCell>
+                  </TableRow>
+                  <TableRow v-for="item in detail.recent_heartbeats" :key="item.id">
+                    <TableCell>{{ formatDate(item.created_at) }}</TableCell>
+                    <TableCell>
+                      <div>{{ item.reported_domain || '-' }}</div>
+                      <div class="text-xs text-muted-foreground">{{ item.reported_ip || '-' }} / {{ item.reported_version || '-' }}</div>
+                    </TableCell>
+                    <TableCell>
+                      <div><Badge :variant="statusBadgeVariant(item.license_status)">{{ item.license_status }}</Badge></div>
+                      <div class="mt-1 text-xs text-muted-foreground">{{ item.message || '-' }}</div>
+                    </TableCell>
+                    <TableCell>
+                      <div><Badge :variant="enforcementBadgeVariant(item.enforcement_action)">{{ item.enforcement_action }}</Badge></div>
+                      <div class="mt-1 text-xs text-muted-foreground">域名 {{ item.matched_domain ? '匹配' : '不匹配' }} / IP {{ item.matched_server_ip ? '匹配' : '不匹配' }}</div>
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </div>
+          </template>
+        </CardContent>
+      </Card>
+    </div>
+
+    <Dialog v-model:open="dialogOpen">
+      <DialogScrollContent class="sm:max-w-3xl">
+        <DialogHeader><DialogTitle>{{ editingLicenseID ? '编辑插件授权' : '新增插件授权' }}</DialogTitle></DialogHeader>
+        <div class="grid gap-4 py-2 md:grid-cols-2">
+          <div class="space-y-2">
+            <Label>插件 ID</Label>
+            <Input v-model="form.plugin_id" placeholder="telegram-suite" />
+          </div>
+          <div class="space-y-2">
+            <Label>方案代码</Label>
+            <Input v-model="form.plan_code" placeholder="annual-basic / perpetual-basic" />
+          </div>
+          <div class="space-y-2">
+            <Label>授权 ID</Label>
+            <Input v-model="form.license_id" placeholder="留空自动生成" />
+          </div>
+          <div class="space-y-2">
+            <Label>License Key</Label>
+            <Input v-model="form.license_key" placeholder="留空自动生成" />
+          </div>
+          <div class="space-y-2">
+            <Label>授权模式</Label>
+            <Select v-model="form.license_mode">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">free</SelectItem>
+                <SelectItem value="annual">annual</SelectItem>
+                <SelectItem value="perpetual">perpetual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="space-y-2">
+            <Label>授权状态</Label>
+            <Select v-model="form.status">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="pending">pending</SelectItem>
+                <SelectItem value="active">active</SelectItem>
+                <SelectItem value="grace">grace</SelectItem>
+                <SelectItem value="expired">expired</SelectItem>
+                <SelectItem value="revoked">revoked</SelectItem>
+                <SelectItem value="suspended">suspended</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="space-y-2">
+            <Label>客户 ID</Label>
+            <Input v-model="form.customer_id" type="number" min="0" />
+          </div>
+          <div class="space-y-2">
+            <Label>订单 ID</Label>
+            <Input v-model="form.order_id" type="number" min="0" />
+          </div>
+          <div class="space-y-2">
+            <Label>绑定域名</Label>
+            <Input v-model="form.bound_domain" placeholder="shop.example.com" />
+          </div>
+          <div class="space-y-2">
+            <Label>绑定服务器 IP</Label>
+            <Input v-model="form.bound_server_ip" placeholder="1.2.3.4" />
+          </div>
+          <div class="space-y-2">
+            <Label>到期时间（RFC3339）</Label>
+            <Input v-model="form.expire_at" placeholder="2026-12-31T00:00:00Z" />
+          </div>
+          <div class="space-y-2">
+            <Label>宽限截止时间（RFC3339）</Label>
+            <Input v-model="form.grace_deadline_at" placeholder="2027-01-15T00:00:00Z" />
+          </div>
+          <div class="space-y-2 md:col-span-2">
+            <Label>功能标记 JSON</Label>
+            <Textarea v-model="form.feature_flags_text" rows="6" />
+          </div>
+          <div class="space-y-2 md:col-span-2">
+            <Label>扩展元数据 JSON</Label>
+            <Textarea v-model="form.meta_text" rows="6" />
+          </div>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <Button variant="outline" @click="dialogOpen = false" :disabled="saving">取消</Button>
+          <Button @click="submitForm" :disabled="saving">{{ saving ? '保存中...' : '保存' }}</Button>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+  </div>
+</template>

--- a/src/views/admin/PluginMarket.vue
+++ b/src/views/admin/PluginMarket.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { adminAPI } from '@/api/admin'
+import type { AdminPluginMarketItem, AdminPluginRegistry } from '@/api/types'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { notifyError, notifySuccess } from '@/utils/notify'
+
+const loading = ref(false)
+const refreshing = ref(false)
+const registries = ref<AdminPluginRegistry[]>([])
+const items = ref<AdminPluginMarketItem[]>([])
+const pagination = ref({ page: 1, page_size: 20, total: 0, total_page: 1 })
+const detailOpen = ref(false)
+const detailLoading = ref(false)
+const detailItem = ref<AdminPluginMarketItem | null>(null)
+const detailVersions = ref<AdminPluginMarketItem[]>([])
+const installLoading = ref('')
+const filters = reactive({ registry_id: '__all__', keyword: '', type: '__all__' })
+
+const normalizeSelectValue = (value: string) => (value === '__all__' ? '' : value)
+
+const loadRegistries = async () => {
+  try {
+    const response = await adminAPI.getPluginRegistries()
+    registries.value = response.data?.data || []
+  } catch (err: any) {
+    registries.value = []
+    notifyError(err?.response?.data?.msg || err?.message || '加载插件库失败')
+  }
+}
+
+const fetchItems = async (page = 1) => {
+  loading.value = true
+  try {
+    const response = await adminAPI.getPluginMarketItems({
+      page,
+      page_size: pagination.value.page_size,
+      registry_id: normalizeSelectValue(filters.registry_id) || undefined,
+      keyword: filters.keyword.trim() || undefined,
+      type: normalizeSelectValue(filters.type) || undefined,
+    })
+    items.value = response.data?.data || []
+    pagination.value = response.data?.pagination || pagination.value
+  } catch (err: any) {
+    items.value = []
+    notifyError(err?.response?.data?.msg || err?.message || '加载在线插件失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const refreshMarket = async () => {
+  refreshing.value = true
+  try {
+    await adminAPI.refreshPluginMarket()
+    notifySuccess('在线插件库已刷新')
+    await Promise.all([loadRegistries(), fetchItems(1)])
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '刷新在线插件库失败')
+  } finally {
+    refreshing.value = false
+  }
+}
+
+const openDetail = async (item: AdminPluginMarketItem) => {
+  detailLoading.value = true
+  try {
+    const response = await adminAPI.getPluginMarketItem(item.plugin_id, { registry_id: item.registry_id })
+    detailItem.value = response.data?.data?.item || null
+    detailVersions.value = response.data?.data?.versions || []
+    detailOpen.value = true
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '加载插件详情失败')
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const installItem = async (item: AdminPluginMarketItem, version?: string) => {
+  const versionValue = version || item.version
+  installLoading.value = `${item.registry_id}:${item.plugin_id}:${versionValue}`
+  try {
+    await adminAPI.installPluginMarketItem(item.plugin_id, { registry_id: item.registry_id, version: versionValue })
+    notifySuccess('插件已导入并安装完成')
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '在线安装失败')
+  } finally {
+    installLoading.value = ''
+  }
+}
+
+const typeLabel = (value?: string) => {
+  const map: Record<string, string> = { theme: '模板', payment: '支付', feature: '功能' }
+  return map[value || ''] || value || '-'
+}
+
+onMounted(async () => {
+  await loadRegistries()
+  await fetchItems(1)
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold">在线插件库</h1>
+        <p class="text-sm text-muted-foreground">浏览官方库与公共市场中的插件元数据，并一键导入到当前系统。</p>
+      </div>
+      <Button variant="outline" :disabled="refreshing" @click="refreshMarket">{{ refreshing ? '刷新中...' : '刷新插件库' }}</Button>
+    </div>
+
+    <Card>
+      <CardHeader><CardTitle>注册表状态</CardTitle></CardHeader>
+      <CardContent class="grid gap-3 lg:grid-cols-2">
+        <div v-for="registry in registries" :key="registry.id" class="rounded-xl border p-4 text-sm">
+          <div class="flex items-center justify-between gap-3">
+            <div class="font-medium">{{ registry.name }}</div>
+            <Badge :variant="registry.last_sync_status === 'ok' ? 'default' : 'outline'">{{ registry.last_sync_status || 'idle' }}</Badge>
+          </div>
+          <div class="mt-2 text-muted-foreground">{{ registry.description }}</div>
+          <div class="mt-2 text-xs text-muted-foreground">最近同步：{{ registry.last_sync_at || '未同步' }}</div>
+          <div class="mt-1 text-xs text-muted-foreground">{{ registry.last_sync_message || '-' }}</div>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader><CardTitle>筛选条件</CardTitle></CardHeader>
+      <CardContent class="flex flex-col gap-3 lg:flex-row">
+        <Select v-model="filters.registry_id" @update:modelValue="fetchItems(1)">
+          <SelectTrigger class="w-full lg:w-52"><SelectValue placeholder="全部来源" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部来源</SelectItem>
+            <SelectItem v-for="registry in registries" :key="registry.id" :value="registry.id">{{ registry.name }}</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select v-model="filters.type" @update:modelValue="fetchItems(1)">
+          <SelectTrigger class="w-full lg:w-40"><SelectValue placeholder="全部类型" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部类型</SelectItem>
+            <SelectItem value="theme">模板</SelectItem>
+            <SelectItem value="payment">支付</SelectItem>
+            <SelectItem value="feature">功能</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input v-model="filters.keyword" placeholder="按插件 ID / 名称 / 作者搜索" @keyup.enter="fetchItems(1)" />
+        <Button @click="fetchItems(1)">搜索</Button>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardContent class="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>插件</TableHead>
+              <TableHead>来源</TableHead>
+              <TableHead>类型</TableHead>
+              <TableHead>版本</TableHead>
+              <TableHead>审核</TableHead>
+              <TableHead class="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow v-if="loading">
+              <TableCell colspan="6" class="py-8 text-center text-muted-foreground">正在加载在线插件列表...</TableCell>
+            </TableRow>
+            <TableRow v-else-if="items.length === 0">
+              <TableCell colspan="6" class="py-8 text-center text-muted-foreground">在线插件库暂时没有数据</TableCell>
+            </TableRow>
+            <TableRow v-for="item in items" :key="`${item.registry_id}-${item.plugin_id}-${item.version}`">
+              <TableCell>
+                <div class="space-y-1">
+                  <div class="font-medium">{{ item.name }}</div>
+                  <div class="text-xs text-muted-foreground">{{ item.plugin_id }}</div>
+                  <div class="text-xs text-muted-foreground">作者：{{ item.author || '-' }}</div>
+                </div>
+              </TableCell>
+              <TableCell>{{ registries.find((registry) => registry.id === item.registry_id)?.name || item.registry_id }}</TableCell>
+              <TableCell>{{ typeLabel(item.type) }}</TableCell>
+              <TableCell>{{ item.version }}</TableCell>
+              <TableCell><Badge variant="outline">{{ item.review_status || 'approved' }}</Badge></TableCell>
+              <TableCell class="text-right">
+                <div class="flex justify-end gap-2">
+                  <Button size="sm" variant="outline" @click="openDetail(item)">详情</Button>
+                  <Button size="sm" :disabled="installLoading === `${item.registry_id}:${item.plugin_id}:${item.version}`" @click="installItem(item)">安装</Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <div>共 {{ pagination.total }} 条记录</div>
+      <div class="flex gap-2">
+        <Button size="sm" variant="outline" :disabled="pagination.page <= 1" @click="fetchItems(pagination.page - 1)">上一页</Button>
+        <Button size="sm" variant="outline" :disabled="pagination.page >= pagination.total_page" @click="fetchItems(pagination.page + 1)">下一页</Button>
+      </div>
+    </div>
+
+    <Dialog v-model:open="detailOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-5xl p-4 sm:p-6">
+        <DialogHeader><DialogTitle>在线插件详情</DialogTitle></DialogHeader>
+        <div v-if="detailLoading" class="py-10 text-center text-sm text-muted-foreground">正在加载插件详情...</div>
+        <div v-else-if="detailItem" class="space-y-6">
+          <div class="grid gap-4 lg:grid-cols-3">
+            <Card>
+              <CardHeader><CardTitle class="text-base">基础信息</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div><span class="text-muted-foreground">插件：</span>{{ detailItem.name }}（{{ detailItem.plugin_id }}）</div>
+                <div><span class="text-muted-foreground">作者：</span>{{ detailItem.author || '-' }}</div>
+                <div><span class="text-muted-foreground">类型：</span>{{ typeLabel(detailItem.type) }}</div>
+                <div><span class="text-muted-foreground">版本：</span>{{ detailItem.version }}</div>
+                <div><span class="text-muted-foreground">宿主协议：</span>{{ detailItem.host_api_version || '-' }}</div>
+                <div><span class="text-muted-foreground">Go 版本：</span>{{ detailItem.go_version || '-' }}</div>
+                <div><span class="text-muted-foreground">构建目标：</span>{{ detailItem.build_target || '-' }}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">权限与校验</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div class="flex flex-wrap gap-2">
+                  <Badge v-for="permission in detailItem.permissions || []" :key="permission" variant="outline">{{ permission }}</Badge>
+                  <span v-if="!detailItem.permissions?.length" class="text-muted-foreground">未声明权限</span>
+                </div>
+                <div><span class="text-muted-foreground">审核状态：</span>{{ detailItem.review_status || 'approved' }}</div>
+                <div class="break-all"><span class="text-muted-foreground">SHA256：</span>{{ detailItem.checksum || '-' }}</div>
+                <div class="break-all"><span class="text-muted-foreground">下载地址：</span>{{ detailItem.download_url || '-' }}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">安装操作</CardTitle></CardHeader>
+              <CardContent class="space-y-3 text-sm">
+                <div class="text-muted-foreground">在线安装会下载插件包、执行结构校验、初始化插件独立数据库，并写入本地插件中心。</div>
+                <Button :disabled="installLoading === `${detailItem.registry_id}:${detailItem.plugin_id}:${detailItem.version}`" @click="installItem(detailItem)">安装当前版本</Button>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader><CardTitle class="text-base">版本列表</CardTitle></CardHeader>
+            <CardContent class="space-y-3">
+              <div v-for="version in detailVersions" :key="`${version.registry_id}-${version.plugin_id}-${version.version}`" class="rounded-lg border p-4 text-sm">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <div class="font-medium">{{ version.version }}</div>
+                    <div class="text-xs text-muted-foreground">{{ version.summary || version.description || '暂无说明' }}</div>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Badge variant="outline">{{ version.review_status || 'approved' }}</Badge>
+                    <Button size="sm" :disabled="installLoading === `${version.registry_id}:${version.plugin_id}:${version.version}`" @click="installItem(version, version.version)">安装此版本</Button>
+                  </div>
+                </div>
+                <div v-if="version.changelog" class="mt-3 rounded bg-muted p-3 text-xs whitespace-pre-wrap">{{ version.changelog }}</div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+  </div>
+</template>

--- a/src/views/admin/PluginMarketCenter.vue
+++ b/src/views/admin/PluginMarketCenter.vue
@@ -1,0 +1,1201 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { adminAPI } from '@/api/admin'
+import type {
+  AdminOnlinePluginDetail,
+  AdminOnlinePluginPlan,
+  AdminOnlinePluginPublisher,
+  AdminOnlinePluginSummary,
+  AdminOnlinePluginVersion,
+} from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import { notifyError, notifySuccess } from '@/utils/notify'
+
+const publisherLoading = ref(false)
+const pluginLoading = ref(false)
+const detailLoading = ref(false)
+const saving = ref(false)
+const deletingKey = ref('')
+
+const publishers = ref<AdminOnlinePluginPublisher[]>([])
+const plugins = ref<AdminOnlinePluginSummary[]>([])
+const detail = ref<AdminOnlinePluginDetail | null>(null)
+const selectedPluginID = ref('')
+const pagination = ref({ page: 1, page_size: 20, total: 0, total_page: 1 })
+
+const filters = reactive({
+  keyword: '',
+  status: '__all__',
+  plugin_type: '__all__',
+  billing_mode: '__all__',
+  publisher_id: '__all__',
+})
+
+const publisherDialogOpen = ref(false)
+const pluginDialogOpen = ref(false)
+const versionDialogOpen = ref(false)
+const planDialogOpen = ref(false)
+
+const editingPublisherID = ref<number | null>(null)
+const editingPluginID = ref<string>('')
+const editingVersionID = ref<number | null>(null)
+const editingPlanID = ref<number | null>(null)
+
+const publisherForm = reactive({
+  publisher_code: '',
+  name: '',
+  contact_email: '',
+  status: 'active',
+  is_official: false,
+  meta_text: '{}',
+})
+
+const pluginForm = reactive({
+  plugin_id: '',
+  slug: '',
+  publisher_id: '',
+  name: '',
+  summary: '',
+  description: '',
+  plugin_type: 'feature',
+  billing_mode: 'free',
+  license_mode: 'free',
+  status: 'draft',
+  is_official: false,
+  is_public: true,
+  icon_url: '',
+  cover_url: '',
+  homepage_url: '',
+  source_url: '',
+  tags_text: '',
+  meta_text: '{}',
+})
+
+const versionForm = reactive({
+  version: '',
+  release_channel: 'stable',
+  package_storage_key: '',
+  package_download_url: '',
+  checksum_sha256: '',
+  package_size_bytes: '0',
+  host_api_version: '',
+  build_target: '',
+  go_version: '',
+  permissions_text: '',
+  config_schema_text: '{}',
+  changelog_md: '',
+  review_status: 'draft',
+  published_at: '',
+  meta_text: '{}',
+})
+
+const planForm = reactive({
+  plan_code: '',
+  plan_name: '',
+  billing_mode: 'free',
+  license_mode: 'free',
+  price_amount: '0',
+  price_currency: 'CNY',
+  duration_days: '',
+  max_sites: '1',
+  max_activations: '1',
+  status: 'active',
+  sort_order: '0',
+  feature_flags_text: '{}',
+  meta_text: '{}',
+})
+
+const currentPlugin = computed(() => detail.value?.plugin || null)
+
+const normalizeSelectValue = (value: string) => (value === '__all__' ? '' : value)
+
+const parseObjectText = (text: string, label: string) => {
+  const raw = text.trim()
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${label}必须是 JSON 对象`)
+    }
+    return parsed as Record<string, unknown>
+  } catch (error: any) {
+    throw new Error(error?.message || `${label}解析失败`)
+  }
+}
+
+const parseStringList = (text: string) =>
+  text
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+
+const stringifyObject = (value: Record<string, unknown> | undefined) => JSON.stringify(value || {}, null, 2)
+
+const stringifyStringList = (value: string[] | undefined) => (value || []).join('\n')
+
+const loadPublishers = async () => {
+  publisherLoading.value = true
+  try {
+    const response = await adminAPI.getPluginMarketCenterPublishers()
+    publishers.value = response.data?.data || []
+  } catch (error: any) {
+    publishers.value = []
+    notifyError(error?.response?.data?.msg || error?.message || '加载发布者失败')
+  } finally {
+    publisherLoading.value = false
+  }
+}
+
+const loadPlugins = async (page = 1) => {
+  pluginLoading.value = true
+  try {
+    const response = await adminAPI.getPluginMarketCenterPlugins({
+      page,
+      page_size: pagination.value.page_size,
+      keyword: filters.keyword.trim() || undefined,
+      status: normalizeSelectValue(filters.status) || undefined,
+      plugin_type: normalizeSelectValue(filters.plugin_type) || undefined,
+      billing_mode: normalizeSelectValue(filters.billing_mode) || undefined,
+      publisher_id: normalizeSelectValue(filters.publisher_id) || undefined,
+    })
+    plugins.value = response.data?.data || []
+    pagination.value = response.data?.pagination || pagination.value
+  } catch (error: any) {
+    plugins.value = []
+    notifyError(error?.response?.data?.msg || error?.message || '加载在线插件中心失败')
+  } finally {
+    pluginLoading.value = false
+  }
+}
+
+const loadDetail = async (pluginID: string) => {
+  if (!pluginID) return
+  detailLoading.value = true
+  selectedPluginID.value = pluginID
+  try {
+    const response = await adminAPI.getPluginMarketCenterPlugin(pluginID)
+    detail.value = response.data?.data || null
+  } catch (error: any) {
+    detail.value = null
+    notifyError(error?.response?.data?.msg || error?.message || '加载插件详情失败')
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const resetPublisherForm = () => {
+  editingPublisherID.value = null
+  publisherForm.publisher_code = ''
+  publisherForm.name = ''
+  publisherForm.contact_email = ''
+  publisherForm.status = 'active'
+  publisherForm.is_official = false
+  publisherForm.meta_text = '{}'
+}
+
+const openPublisherDialog = (item?: AdminOnlinePluginPublisher) => {
+  resetPublisherForm()
+  if (item) {
+    editingPublisherID.value = item.id
+    publisherForm.publisher_code = item.publisher_code
+    publisherForm.name = item.name
+    publisherForm.contact_email = item.contact_email || ''
+    publisherForm.status = item.status || 'active'
+    publisherForm.is_official = !!item.is_official
+    publisherForm.meta_text = stringifyObject(item.meta)
+  }
+  publisherDialogOpen.value = true
+}
+
+const submitPublisher = async () => {
+  saving.value = true
+  try {
+    const payload = {
+      publisher_code: publisherForm.publisher_code,
+      name: publisherForm.name,
+      contact_email: publisherForm.contact_email,
+      status: publisherForm.status,
+      is_official: publisherForm.is_official,
+      meta: parseObjectText(publisherForm.meta_text, '发布者 Meta'),
+    }
+    if (editingPublisherID.value) {
+      await adminAPI.updatePluginMarketCenterPublisher(editingPublisherID.value, payload)
+      notifySuccess('发布者已更新')
+    } else {
+      await adminAPI.createPluginMarketCenterPublisher(payload)
+      notifySuccess('发布者已创建')
+    }
+    publisherDialogOpen.value = false
+    await Promise.all([loadPublishers(), loadPlugins(pagination.value.page)])
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '保存发布者失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const deletePublisher = async (item: AdminOnlinePluginPublisher) => {
+  if (!window.confirm(`确认删除发布者「${item.name}」吗？`)) return
+  deletingKey.value = `publisher:${item.id}`
+  try {
+    await adminAPI.deletePluginMarketCenterPublisher(item.id)
+    notifySuccess('发布者已删除')
+    await Promise.all([loadPublishers(), loadPlugins(pagination.value.page)])
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '删除发布者失败')
+  } finally {
+    deletingKey.value = ''
+  }
+}
+
+const resetPluginForm = () => {
+  editingPluginID.value = ''
+  pluginForm.plugin_id = ''
+  pluginForm.slug = ''
+  pluginForm.publisher_id = publishers.value[0] ? String(publishers.value[0].id) : ''
+  pluginForm.name = ''
+  pluginForm.summary = ''
+  pluginForm.description = ''
+  pluginForm.plugin_type = 'feature'
+  pluginForm.billing_mode = 'free'
+  pluginForm.license_mode = 'free'
+  pluginForm.status = 'draft'
+  pluginForm.is_official = false
+  pluginForm.is_public = true
+  pluginForm.icon_url = ''
+  pluginForm.cover_url = ''
+  pluginForm.homepage_url = ''
+  pluginForm.source_url = ''
+  pluginForm.tags_text = ''
+  pluginForm.meta_text = '{}'
+}
+
+const openPluginDialog = (item?: AdminOnlinePluginSummary | AdminOnlinePluginDetail | null) => {
+  resetPluginForm()
+  const plugin = item && 'plugin' in item ? item.plugin : null
+  if (plugin) {
+    editingPluginID.value = plugin.plugin_id
+    pluginForm.plugin_id = plugin.plugin_id
+    pluginForm.slug = plugin.slug
+    pluginForm.publisher_id = String(plugin.publisher_id)
+    pluginForm.name = plugin.name
+    pluginForm.summary = plugin.summary || ''
+    pluginForm.description = plugin.description || ''
+    pluginForm.plugin_type = plugin.plugin_type || 'feature'
+    pluginForm.billing_mode = plugin.billing_mode || 'free'
+    pluginForm.license_mode = plugin.license_mode || 'free'
+    pluginForm.status = plugin.status || 'draft'
+    pluginForm.is_official = !!plugin.is_official
+    pluginForm.is_public = !!plugin.is_public
+    pluginForm.icon_url = plugin.icon_url || ''
+    pluginForm.cover_url = plugin.cover_url || ''
+    pluginForm.homepage_url = plugin.homepage_url || ''
+    pluginForm.source_url = plugin.source_url || ''
+    pluginForm.tags_text = stringifyStringList(plugin.tags)
+    pluginForm.meta_text = stringifyObject(plugin.meta)
+  }
+  pluginDialogOpen.value = true
+}
+
+const submitPlugin = async () => {
+  saving.value = true
+  try {
+    const payload = {
+      plugin_id: pluginForm.plugin_id,
+      slug: pluginForm.slug,
+      publisher_id: Number(pluginForm.publisher_id || 0),
+      name: pluginForm.name,
+      summary: pluginForm.summary,
+      description: pluginForm.description,
+      plugin_type: pluginForm.plugin_type,
+      billing_mode: pluginForm.billing_mode,
+      license_mode: pluginForm.license_mode,
+      status: pluginForm.status,
+      is_official: pluginForm.is_official,
+      is_public: pluginForm.is_public,
+      icon_url: pluginForm.icon_url,
+      cover_url: pluginForm.cover_url,
+      homepage_url: pluginForm.homepage_url,
+      source_url: pluginForm.source_url,
+      tags: parseStringList(pluginForm.tags_text),
+      meta: parseObjectText(pluginForm.meta_text, '插件 Meta'),
+    }
+    const targetPluginID = editingPluginID.value || payload.plugin_id
+    if (editingPluginID.value) {
+      await adminAPI.updatePluginMarketCenterPlugin(editingPluginID.value, payload)
+      notifySuccess('在线插件已更新')
+    } else {
+      await adminAPI.createPluginMarketCenterPlugin(payload)
+      notifySuccess('在线插件已创建')
+    }
+    pluginDialogOpen.value = false
+    await Promise.all([loadPublishers(), loadPlugins(editingPluginID.value ? pagination.value.page : 1)])
+    await loadDetail(targetPluginID)
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '保存在线插件失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const deletePlugin = async (item: AdminOnlinePluginSummary | AdminOnlinePluginDetail) => {
+  const plugin = item.plugin
+  if (!window.confirm(`确认删除插件「${plugin.name}」吗？版本与套餐也会一起删除。`)) return
+  deletingKey.value = `plugin:${plugin.plugin_id}`
+  try {
+    await adminAPI.deletePluginMarketCenterPlugin(plugin.plugin_id)
+    notifySuccess('在线插件已删除')
+    if (selectedPluginID.value === plugin.plugin_id) {
+      detail.value = null
+      selectedPluginID.value = ''
+    }
+    await loadPlugins(pagination.value.page)
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '删除在线插件失败')
+  } finally {
+    deletingKey.value = ''
+  }
+}
+
+const resetVersionForm = () => {
+  editingVersionID.value = null
+  versionForm.version = ''
+  versionForm.release_channel = 'stable'
+  versionForm.package_storage_key = ''
+  versionForm.package_download_url = ''
+  versionForm.checksum_sha256 = ''
+  versionForm.package_size_bytes = '0'
+  versionForm.host_api_version = ''
+  versionForm.build_target = ''
+  versionForm.go_version = ''
+  versionForm.permissions_text = ''
+  versionForm.config_schema_text = '{}'
+  versionForm.changelog_md = ''
+  versionForm.review_status = 'draft'
+  versionForm.published_at = ''
+  versionForm.meta_text = '{}'
+}
+
+const openVersionDialog = (item?: AdminOnlinePluginVersion) => {
+  if (!currentPlugin.value) {
+    notifyError('请先选择一个插件')
+    return
+  }
+  resetVersionForm()
+  if (item) {
+    editingVersionID.value = item.id
+    versionForm.version = item.version
+    versionForm.release_channel = item.release_channel || 'stable'
+    versionForm.package_storage_key = item.package_storage_key || ''
+    versionForm.package_download_url = item.package_download_url || ''
+    versionForm.checksum_sha256 = item.checksum_sha256 || ''
+    versionForm.package_size_bytes = String(item.package_size_bytes || 0)
+    versionForm.host_api_version = item.host_api_version || ''
+    versionForm.build_target = item.build_target || ''
+    versionForm.go_version = item.go_version || ''
+    versionForm.permissions_text = stringifyStringList(item.permissions)
+    versionForm.config_schema_text = stringifyObject(item.config_schema)
+    versionForm.changelog_md = item.changelog_md || ''
+    versionForm.review_status = item.review_status || 'draft'
+    versionForm.published_at = item.published_at || ''
+    versionForm.meta_text = stringifyObject(item.meta)
+  }
+  versionDialogOpen.value = true
+}
+
+const submitVersion = async () => {
+  if (!currentPlugin.value) return
+  saving.value = true
+  try {
+    const payload = {
+      version: versionForm.version,
+      release_channel: versionForm.release_channel,
+      package_storage_key: versionForm.package_storage_key,
+      package_download_url: versionForm.package_download_url,
+      checksum_sha256: versionForm.checksum_sha256,
+      package_size_bytes: Number(versionForm.package_size_bytes || 0),
+      host_api_version: versionForm.host_api_version,
+      build_target: versionForm.build_target,
+      go_version: versionForm.go_version,
+      permissions: parseStringList(versionForm.permissions_text),
+      config_schema: parseObjectText(versionForm.config_schema_text, '版本配置 Schema'),
+      changelog_md: versionForm.changelog_md,
+      review_status: versionForm.review_status,
+      published_at: versionForm.published_at.trim() || undefined,
+      meta: parseObjectText(versionForm.meta_text, '版本 Meta'),
+    }
+    if (editingVersionID.value) {
+      await adminAPI.updatePluginMarketCenterVersion(editingVersionID.value, payload)
+      notifySuccess('版本已更新')
+    } else {
+      await adminAPI.createPluginMarketCenterVersion(currentPlugin.value.plugin_id, payload)
+      notifySuccess('版本已创建')
+    }
+    versionDialogOpen.value = false
+    await Promise.all([loadDetail(currentPlugin.value.plugin_id), loadPlugins(pagination.value.page)])
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '保存版本失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const deleteVersion = async (item: AdminOnlinePluginVersion) => {
+  if (!currentPlugin.value || !window.confirm(`确认删除版本「${item.version}」吗？`)) return
+  deletingKey.value = `version:${item.id}`
+  try {
+    await adminAPI.deletePluginMarketCenterVersion(item.id)
+    notifySuccess('版本已删除')
+    await Promise.all([loadDetail(currentPlugin.value.plugin_id), loadPlugins(pagination.value.page)])
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '删除版本失败')
+  } finally {
+    deletingKey.value = ''
+  }
+}
+
+const resetPlanForm = () => {
+  editingPlanID.value = null
+  planForm.plan_code = ''
+  planForm.plan_name = ''
+  planForm.billing_mode = 'free'
+  planForm.license_mode = 'free'
+  planForm.price_amount = '0'
+  planForm.price_currency = 'CNY'
+  planForm.duration_days = ''
+  planForm.max_sites = '1'
+  planForm.max_activations = '1'
+  planForm.status = 'active'
+  planForm.sort_order = '0'
+  planForm.feature_flags_text = '{}'
+  planForm.meta_text = '{}'
+}
+
+const openPlanDialog = (item?: AdminOnlinePluginPlan) => {
+  if (!currentPlugin.value) {
+    notifyError('请先选择一个插件')
+    return
+  }
+  resetPlanForm()
+  if (item) {
+    editingPlanID.value = item.id
+    planForm.plan_code = item.plan_code
+    planForm.plan_name = item.plan_name
+    planForm.billing_mode = item.billing_mode || 'free'
+    planForm.license_mode = item.license_mode || 'free'
+    planForm.price_amount = item.price_amount || '0'
+    planForm.price_currency = item.price_currency || 'CNY'
+    planForm.duration_days = item.duration_days ? String(item.duration_days) : ''
+    planForm.max_sites = String(item.max_sites || 1)
+    planForm.max_activations = String(item.max_activations || 1)
+    planForm.status = item.status || 'active'
+    planForm.sort_order = String(item.sort_order || 0)
+    planForm.feature_flags_text = stringifyObject(item.feature_flags)
+    planForm.meta_text = stringifyObject(item.meta)
+  }
+  planDialogOpen.value = true
+}
+
+const submitPlan = async () => {
+  if (!currentPlugin.value) return
+  saving.value = true
+  try {
+    const payload = {
+      plan_code: planForm.plan_code,
+      plan_name: planForm.plan_name,
+      billing_mode: planForm.billing_mode,
+      license_mode: planForm.license_mode,
+      price_amount: planForm.price_amount,
+      price_currency: planForm.price_currency,
+      duration_days: planForm.duration_days.trim() ? Number(planForm.duration_days) : undefined,
+      max_sites: Number(planForm.max_sites || 1),
+      max_activations: Number(planForm.max_activations || 1),
+      status: planForm.status,
+      sort_order: Number(planForm.sort_order || 0),
+      feature_flags: parseObjectText(planForm.feature_flags_text, '套餐功能标记'),
+      meta: parseObjectText(planForm.meta_text, '套餐 Meta'),
+    }
+    if (editingPlanID.value) {
+      await adminAPI.updatePluginMarketCenterPlan(editingPlanID.value, payload)
+      notifySuccess('套餐已更新')
+    } else {
+      await adminAPI.createPluginMarketCenterPlan(currentPlugin.value.plugin_id, payload)
+      notifySuccess('套餐已创建')
+    }
+    planDialogOpen.value = false
+    await loadDetail(currentPlugin.value.plugin_id)
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '保存套餐失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+const deletePlan = async (item: AdminOnlinePluginPlan) => {
+  if (!currentPlugin.value || !window.confirm(`确认删除套餐「${item.plan_name}」吗？`)) return
+  deletingKey.value = `plan:${item.id}`
+  try {
+    await adminAPI.deletePluginMarketCenterPlan(item.id)
+    notifySuccess('套餐已删除')
+    await loadDetail(currentPlugin.value.plugin_id)
+  } catch (error: any) {
+    notifyError(error?.response?.data?.msg || error?.message || '删除套餐失败')
+  } finally {
+    deletingKey.value = ''
+  }
+}
+
+const publisherName = (summary: AdminOnlinePluginSummary) => summary.publisher?.name || '-'
+const statusBadgeVariant = (value?: string) => (value === 'published' || value === 'active' ? 'default' : 'outline')
+
+onMounted(async () => {
+  await loadPublishers()
+  await loadPlugins(1)
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold">在线插件中心</h1>
+        <p class="text-sm text-muted-foreground">管理官方插件市场的发布者、插件主记录、版本包与收费套餐，为后续 `app.vipmax.shop` 与 `key.vipmax.shop` 打底。</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <Button variant="outline" @click="openPublisherDialog()">新增发布者</Button>
+        <Button @click="openPluginDialog()">新增插件</Button>
+      </div>
+    </div>
+
+    <Card>
+      <CardHeader class="flex flex-row items-center justify-between">
+        <CardTitle>发布者</CardTitle>
+        <div class="text-sm text-muted-foreground">共 {{ publishers.length }} 个</div>
+      </CardHeader>
+      <CardContent class="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>编码</TableHead>
+              <TableHead>名称</TableHead>
+              <TableHead>联系邮箱</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead class="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow v-if="publisherLoading">
+              <TableCell colspan="5" class="py-6 text-center text-muted-foreground">正在加载发布者...</TableCell>
+            </TableRow>
+            <TableRow v-else-if="publishers.length === 0">
+              <TableCell colspan="5" class="py-6 text-center text-muted-foreground">还没有发布者，先创建一个官方或第三方发布者。</TableCell>
+            </TableRow>
+            <TableRow v-for="item in publishers" :key="item.id">
+              <TableCell>{{ item.publisher_code }}</TableCell>
+              <TableCell>
+                <div class="flex items-center gap-2">
+                  <span>{{ item.name }}</span>
+                  <Badge v-if="item.is_official">官方</Badge>
+                </div>
+              </TableCell>
+              <TableCell>{{ item.contact_email || '-' }}</TableCell>
+              <TableCell><Badge :variant="statusBadgeVariant(item.status)">{{ item.status }}</Badge></TableCell>
+              <TableCell class="text-right">
+                <div class="flex justify-end gap-2">
+                  <Button size="sm" variant="outline" @click="openPublisherDialog(item)">编辑</Button>
+                  <Button size="sm" variant="outline" :disabled="deletingKey === `publisher:${item.id}`" @click="deletePublisher(item)">删除</Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader><CardTitle>插件筛选</CardTitle></CardHeader>
+      <CardContent class="grid gap-3 lg:grid-cols-5">
+        <Input v-model="filters.keyword" placeholder="按插件 ID / 名称 / slug 搜索" @keyup.enter="loadPlugins(1)" />
+        <Select v-model="filters.publisher_id" @update:modelValue="loadPlugins(1)">
+          <SelectTrigger><SelectValue placeholder="全部发布者" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部发布者</SelectItem>
+            <SelectItem v-for="item in publishers" :key="item.id" :value="String(item.id)">{{ item.name }}</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select v-model="filters.status" @update:modelValue="loadPlugins(1)">
+          <SelectTrigger><SelectValue placeholder="全部状态" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部状态</SelectItem>
+            <SelectItem value="draft">草稿</SelectItem>
+            <SelectItem value="pending_review">待审核</SelectItem>
+            <SelectItem value="published">已发布</SelectItem>
+            <SelectItem value="hidden">隐藏</SelectItem>
+            <SelectItem value="archived">归档</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select v-model="filters.plugin_type" @update:modelValue="loadPlugins(1)">
+          <SelectTrigger><SelectValue placeholder="全部类型" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部类型</SelectItem>
+            <SelectItem value="feature">功能</SelectItem>
+            <SelectItem value="payment">支付</SelectItem>
+            <SelectItem value="theme">模板</SelectItem>
+          </SelectContent>
+        </Select>
+        <div class="flex gap-2">
+          <Select v-model="filters.billing_mode" @update:modelValue="loadPlugins(1)">
+            <SelectTrigger><SelectValue placeholder="全部计费" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">全部计费</SelectItem>
+              <SelectItem value="free">免费</SelectItem>
+              <SelectItem value="annual">年付</SelectItem>
+              <SelectItem value="perpetual">买断</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button @click="loadPlugins(1)">搜索</Button>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader class="flex flex-row items-center justify-between">
+        <CardTitle>插件列表</CardTitle>
+        <div class="text-sm text-muted-foreground">共 {{ pagination.total }} 条记录</div>
+      </CardHeader>
+      <CardContent class="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>插件</TableHead>
+              <TableHead>发布者</TableHead>
+              <TableHead>类型</TableHead>
+              <TableHead>计费</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead>最新版本</TableHead>
+              <TableHead class="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow v-if="pluginLoading">
+              <TableCell colspan="7" class="py-8 text-center text-muted-foreground">正在加载插件...</TableCell>
+            </TableRow>
+            <TableRow v-else-if="plugins.length === 0">
+              <TableCell colspan="7" class="py-8 text-center text-muted-foreground">还没有插件数据，先新增一个插件主记录。</TableCell>
+            </TableRow>
+            <TableRow
+              v-for="item in plugins"
+              :key="item.plugin.plugin_id"
+              class="cursor-pointer"
+              :class="selectedPluginID === item.plugin.plugin_id ? 'bg-muted/40' : ''"
+              @click="loadDetail(item.plugin.plugin_id)"
+            >
+              <TableCell>
+                <div class="space-y-1">
+                  <div class="font-medium">{{ item.plugin.name }}</div>
+                  <div class="text-xs text-muted-foreground">{{ item.plugin.plugin_id }}</div>
+                </div>
+              </TableCell>
+              <TableCell>{{ publisherName(item) }}</TableCell>
+              <TableCell>{{ item.plugin.plugin_type }}</TableCell>
+              <TableCell>{{ item.plugin.billing_mode }}</TableCell>
+              <TableCell>
+                <div class="flex items-center gap-2">
+                  <Badge :variant="statusBadgeVariant(item.plugin.status)">{{ item.plugin.status }}</Badge>
+                  <Badge v-if="item.plugin.is_official" variant="outline">官方</Badge>
+                  <Badge v-if="item.plugin.is_public" variant="outline">公开</Badge>
+                </div>
+              </TableCell>
+              <TableCell>{{ item.latest_version?.version || '-' }}</TableCell>
+              <TableCell class="text-right">
+                <div class="flex justify-end gap-2">
+                  <Button size="sm" variant="outline" @click.stop="openPluginDialog(item)">编辑</Button>
+                  <Button size="sm" variant="outline" :disabled="deletingKey === `plugin:${item.plugin.plugin_id}`" @click.stop="deletePlugin(item)">删除</Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <div>当前第 {{ pagination.page }} / {{ pagination.total_page }} 页</div>
+      <div class="flex gap-2">
+        <Button size="sm" variant="outline" :disabled="pagination.page <= 1" @click="loadPlugins(pagination.page - 1)">上一页</Button>
+        <Button size="sm" variant="outline" :disabled="pagination.page >= pagination.total_page" @click="loadPlugins(pagination.page + 1)">下一页</Button>
+      </div>
+    </div>
+
+    <Card v-if="selectedPluginID">
+      <CardHeader class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <CardTitle>插件详情</CardTitle>
+          <p class="mt-1 text-sm text-muted-foreground">{{ currentPlugin?.name || selectedPluginID }}</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <Button variant="outline" @click="openPluginDialog(detail)">编辑插件</Button>
+          <Button variant="outline" @click="openVersionDialog()">新增版本</Button>
+          <Button variant="outline" @click="openPlanDialog()">新增套餐</Button>
+        </div>
+      </CardHeader>
+      <CardContent v-if="detailLoading" class="py-10 text-center text-sm text-muted-foreground">正在加载详情...</CardContent>
+      <CardContent v-else-if="detail" class="space-y-6">
+        <div class="grid gap-4 lg:grid-cols-3">
+          <Card>
+            <CardHeader><CardTitle class="text-base">基础信息</CardTitle></CardHeader>
+            <CardContent class="space-y-2 text-sm">
+              <div><span class="text-muted-foreground">插件 ID：</span>{{ detail.plugin.plugin_id }}</div>
+              <div><span class="text-muted-foreground">Slug：</span>{{ detail.plugin.slug }}</div>
+              <div><span class="text-muted-foreground">发布者：</span>{{ detail.publisher?.name || '-' }}</div>
+              <div><span class="text-muted-foreground">类型：</span>{{ detail.plugin.plugin_type }}</div>
+              <div><span class="text-muted-foreground">计费：</span>{{ detail.plugin.billing_mode }}</div>
+              <div><span class="text-muted-foreground">授权：</span>{{ detail.plugin.license_mode }}</div>
+              <div><span class="text-muted-foreground">状态：</span>{{ detail.plugin.status }}</div>
+              <div class="text-muted-foreground">摘要：{{ detail.plugin.summary || '暂无摘要' }}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader><CardTitle class="text-base">对外展示</CardTitle></CardHeader>
+            <CardContent class="space-y-2 text-sm">
+              <div><span class="text-muted-foreground">首页：</span>{{ detail.plugin.homepage_url || '-' }}</div>
+              <div><span class="text-muted-foreground">源码：</span>{{ detail.plugin.source_url || '-' }}</div>
+              <div><span class="text-muted-foreground">图标：</span>{{ detail.plugin.icon_url || '-' }}</div>
+              <div><span class="text-muted-foreground">封面：</span>{{ detail.plugin.cover_url || '-' }}</div>
+              <div class="flex flex-wrap gap-2">
+                <Badge v-for="tag in detail.plugin.tags || []" :key="tag" variant="outline">{{ tag }}</Badge>
+                <span v-if="!detail.plugin.tags?.length" class="text-muted-foreground">无标签</span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader><CardTitle class="text-base">当前发布态</CardTitle></CardHeader>
+            <CardContent class="space-y-2 text-sm">
+              <div><span class="text-muted-foreground">最新版本：</span>{{ detail.latest_version?.version || '-' }}</div>
+              <div><span class="text-muted-foreground">公开市场：</span>{{ detail.plugin.is_public ? '是' : '否' }}</div>
+              <div><span class="text-muted-foreground">官方插件：</span>{{ detail.plugin.is_official ? '是' : '否' }}</div>
+              <div><span class="text-muted-foreground">版本数：</span>{{ detail.versions.length }}</div>
+              <div><span class="text-muted-foreground">套餐数：</span>{{ detail.plans.length }}</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader><CardTitle class="text-base">版本</CardTitle></CardHeader>
+          <CardContent class="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>版本</TableHead>
+                  <TableHead>渠道</TableHead>
+                  <TableHead>审核</TableHead>
+                  <TableHead>下载地址</TableHead>
+                  <TableHead class="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow v-if="detail.versions.length === 0">
+                  <TableCell colspan="5" class="py-6 text-center text-muted-foreground">还没有版本记录</TableCell>
+                </TableRow>
+                <TableRow v-for="item in detail.versions" :key="item.id">
+                  <TableCell>{{ item.version }}</TableCell>
+                  <TableCell>{{ item.release_channel }}</TableCell>
+                  <TableCell><Badge :variant="statusBadgeVariant(item.review_status)">{{ item.review_status }}</Badge></TableCell>
+                  <TableCell class="max-w-[420px] truncate">{{ item.package_download_url || '-' }}</TableCell>
+                  <TableCell class="text-right">
+                    <div class="flex justify-end gap-2">
+                      <Button size="sm" variant="outline" @click="openVersionDialog(item)">编辑</Button>
+                      <Button size="sm" variant="outline" :disabled="deletingKey === `version:${item.id}`" @click="deleteVersion(item)">删除</Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle class="text-base">套餐</CardTitle></CardHeader>
+          <CardContent class="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>套餐</TableHead>
+                  <TableHead>计费</TableHead>
+                  <TableHead>价格</TableHead>
+                  <TableHead>授权限制</TableHead>
+                  <TableHead class="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow v-if="detail.plans.length === 0">
+                  <TableCell colspan="5" class="py-6 text-center text-muted-foreground">还没有套餐记录</TableCell>
+                </TableRow>
+                <TableRow v-for="item in detail.plans" :key="item.id">
+                  <TableCell>
+                    <div class="space-y-1">
+                      <div class="font-medium">{{ item.plan_name }}</div>
+                      <div class="text-xs text-muted-foreground">{{ item.plan_code }}</div>
+                    </div>
+                  </TableCell>
+                  <TableCell>{{ item.billing_mode }}</TableCell>
+                  <TableCell>{{ item.price_amount }} {{ item.price_currency }}</TableCell>
+                  <TableCell>站点 {{ item.max_sites }} / 激活 {{ item.max_activations }}</TableCell>
+                  <TableCell class="text-right">
+                    <div class="flex justify-end gap-2">
+                      <Button size="sm" variant="outline" @click="openPlanDialog(item)">编辑</Button>
+                      <Button size="sm" variant="outline" :disabled="deletingKey === `plan:${item.id}`" @click="deletePlan(item)">删除</Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </CardContent>
+    </Card>
+
+    <Dialog v-model:open="publisherDialogOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-2xl p-4 sm:p-6">
+        <DialogHeader><DialogTitle>{{ editingPublisherID ? '编辑发布者' : '新增发布者' }}</DialogTitle></DialogHeader>
+        <div class="grid gap-4">
+          <div class="grid gap-2">
+            <Label>发布者编码</Label>
+            <Input v-model="publisherForm.publisher_code" placeholder="official-team" />
+          </div>
+          <div class="grid gap-2">
+            <Label>名称</Label>
+            <Input v-model="publisherForm.name" placeholder="官方团队" />
+          </div>
+          <div class="grid gap-2">
+            <Label>联系邮箱</Label>
+            <Input v-model="publisherForm.contact_email" placeholder="team@example.com" />
+          </div>
+          <div class="grid gap-2">
+            <Label>状态</Label>
+            <Select v-model="publisherForm.status">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="active">active</SelectItem>
+                <SelectItem value="disabled">disabled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <label class="flex items-center gap-2 text-sm">
+            <input v-model="publisherForm.is_official" type="checkbox" />
+            标记为官方发布者
+          </label>
+          <div class="grid gap-2">
+            <Label>Meta JSON</Label>
+            <Textarea v-model="publisherForm.meta_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="flex justify-end gap-2">
+            <Button variant="outline" @click="publisherDialogOpen = false">取消</Button>
+            <Button :disabled="saving" @click="submitPublisher">{{ saving ? '保存中...' : '保存' }}</Button>
+          </div>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+
+    <Dialog v-model:open="pluginDialogOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-4xl p-4 sm:p-6">
+        <DialogHeader><DialogTitle>{{ editingPluginID ? '编辑在线插件' : '新增在线插件' }}</DialogTitle></DialogHeader>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <div class="grid gap-2">
+            <Label>插件 ID</Label>
+            <Input v-model="pluginForm.plugin_id" placeholder="telegram-suite" />
+          </div>
+          <div class="grid gap-2">
+            <Label>Slug</Label>
+            <Input v-model="pluginForm.slug" placeholder="telegram-suite" />
+          </div>
+          <div class="grid gap-2">
+            <Label>发布者</Label>
+            <Select v-model="pluginForm.publisher_id">
+              <SelectTrigger><SelectValue placeholder="选择发布者" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem v-for="item in publishers" :key="item.id" :value="String(item.id)">{{ item.name }}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>名称</Label>
+            <Input v-model="pluginForm.name" placeholder="Telegram Suite" />
+          </div>
+          <div class="grid gap-2">
+            <Label>插件类型</Label>
+            <Select v-model="pluginForm.plugin_type">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="feature">feature</SelectItem>
+                <SelectItem value="payment">payment</SelectItem>
+                <SelectItem value="theme">theme</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>状态</Label>
+            <Select v-model="pluginForm.status">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">draft</SelectItem>
+                <SelectItem value="pending_review">pending_review</SelectItem>
+                <SelectItem value="published">published</SelectItem>
+                <SelectItem value="hidden">hidden</SelectItem>
+                <SelectItem value="archived">archived</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>计费模式</Label>
+            <Select v-model="pluginForm.billing_mode">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">free</SelectItem>
+                <SelectItem value="annual">annual</SelectItem>
+                <SelectItem value="perpetual">perpetual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>授权模式</Label>
+            <Select v-model="pluginForm.license_mode">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">free</SelectItem>
+                <SelectItem value="annual">annual</SelectItem>
+                <SelectItem value="perpetual">perpetual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>摘要</Label>
+            <Textarea v-model="pluginForm.summary" rows="2" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>描述</Label>
+            <Textarea v-model="pluginForm.description" rows="4" />
+          </div>
+          <div class="grid gap-2">
+            <Label>图标 URL</Label>
+            <Input v-model="pluginForm.icon_url" />
+          </div>
+          <div class="grid gap-2">
+            <Label>封面 URL</Label>
+            <Input v-model="pluginForm.cover_url" />
+          </div>
+          <div class="grid gap-2">
+            <Label>首页 URL</Label>
+            <Input v-model="pluginForm.homepage_url" />
+          </div>
+          <div class="grid gap-2">
+            <Label>源码 URL</Label>
+            <Input v-model="pluginForm.source_url" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>标签（逗号或换行分隔）</Label>
+            <Textarea v-model="pluginForm.tags_text" rows="3" />
+          </div>
+          <div class="flex flex-wrap gap-4 lg:col-span-2 text-sm">
+            <label class="flex items-center gap-2">
+              <input v-model="pluginForm.is_official" type="checkbox" />
+              官方插件
+            </label>
+            <label class="flex items-center gap-2">
+              <input v-model="pluginForm.is_public" type="checkbox" />
+              公开展示
+            </label>
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>Meta JSON</Label>
+            <Textarea v-model="pluginForm.meta_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="flex justify-end gap-2 lg:col-span-2">
+            <Button variant="outline" @click="pluginDialogOpen = false">取消</Button>
+            <Button :disabled="saving" @click="submitPlugin">{{ saving ? '保存中...' : '保存' }}</Button>
+          </div>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+
+    <Dialog v-model:open="versionDialogOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-4xl p-4 sm:p-6">
+        <DialogHeader><DialogTitle>{{ editingVersionID ? '编辑版本' : '新增版本' }}</DialogTitle></DialogHeader>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <div class="grid gap-2">
+            <Label>版本号</Label>
+            <Input v-model="versionForm.version" placeholder="1.0.0" />
+          </div>
+          <div class="grid gap-2">
+            <Label>发布渠道</Label>
+            <Select v-model="versionForm.release_channel">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="stable">stable</SelectItem>
+                <SelectItem value="beta">beta</SelectItem>
+                <SelectItem value="alpha">alpha</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>宿主协议版本</Label>
+            <Input v-model="versionForm.host_api_version" placeholder="v1" />
+          </div>
+          <div class="grid gap-2">
+            <Label>构建目标</Label>
+            <Input v-model="versionForm.build_target" placeholder="linux-amd64" />
+          </div>
+          <div class="grid gap-2">
+            <Label>Go 版本</Label>
+            <Input v-model="versionForm.go_version" placeholder="go1.24.0" />
+          </div>
+          <div class="grid gap-2">
+            <Label>包大小（字节）</Label>
+            <Input v-model="versionForm.package_size_bytes" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>下载地址</Label>
+            <Input v-model="versionForm.package_download_url" placeholder="https://app.vipmax.shop/packages/telegram-suite-1.0.0.zip" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>存储键</Label>
+            <Input v-model="versionForm.package_storage_key" placeholder="packages/telegram-suite/1.0.0.zip" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>SHA256</Label>
+            <Input v-model="versionForm.checksum_sha256" placeholder="sha256 值" />
+          </div>
+          <div class="grid gap-2">
+            <Label>审核状态</Label>
+            <Select v-model="versionForm.review_status">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">draft</SelectItem>
+                <SelectItem value="pending_review">pending_review</SelectItem>
+                <SelectItem value="approved">approved</SelectItem>
+                <SelectItem value="rejected">rejected</SelectItem>
+                <SelectItem value="published">published</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>发布时间（RFC3339）</Label>
+            <Input v-model="versionForm.published_at" placeholder="2026-04-13T18:00:00Z" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>权限声明（逗号或换行分隔）</Label>
+            <Textarea v-model="versionForm.permissions_text" rows="3" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>配置 Schema JSON</Label>
+            <Textarea v-model="versionForm.config_schema_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>更新日志</Label>
+            <Textarea v-model="versionForm.changelog_md" rows="5" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>Meta JSON</Label>
+            <Textarea v-model="versionForm.meta_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="flex justify-end gap-2 lg:col-span-2">
+            <Button variant="outline" @click="versionDialogOpen = false">取消</Button>
+            <Button :disabled="saving" @click="submitVersion">{{ saving ? '保存中...' : '保存' }}</Button>
+          </div>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+
+    <Dialog v-model:open="planDialogOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-3xl p-4 sm:p-6">
+        <DialogHeader><DialogTitle>{{ editingPlanID ? '编辑套餐' : '新增套餐' }}</DialogTitle></DialogHeader>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <div class="grid gap-2">
+            <Label>套餐编码</Label>
+            <Input v-model="planForm.plan_code" placeholder="annual-basic" />
+          </div>
+          <div class="grid gap-2">
+            <Label>套餐名称</Label>
+            <Input v-model="planForm.plan_name" placeholder="年付基础版" />
+          </div>
+          <div class="grid gap-2">
+            <Label>计费模式</Label>
+            <Select v-model="planForm.billing_mode">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">free</SelectItem>
+                <SelectItem value="annual">annual</SelectItem>
+                <SelectItem value="perpetual">perpetual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>授权模式</Label>
+            <Select v-model="planForm.license_mode">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">free</SelectItem>
+                <SelectItem value="annual">annual</SelectItem>
+                <SelectItem value="perpetual">perpetual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>价格</Label>
+            <Input v-model="planForm.price_amount" placeholder="99.00" />
+          </div>
+          <div class="grid gap-2">
+            <Label>币种</Label>
+            <Input v-model="planForm.price_currency" placeholder="CNY" />
+          </div>
+          <div class="grid gap-2">
+            <Label>有效天数</Label>
+            <Input v-model="planForm.duration_days" placeholder="365，买断可留空" />
+          </div>
+          <div class="grid gap-2">
+            <Label>状态</Label>
+            <Select v-model="planForm.status">
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="active">active</SelectItem>
+                <SelectItem value="disabled">disabled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-2">
+            <Label>最大站点数</Label>
+            <Input v-model="planForm.max_sites" />
+          </div>
+          <div class="grid gap-2">
+            <Label>最大激活数</Label>
+            <Input v-model="planForm.max_activations" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>排序值</Label>
+            <Input v-model="planForm.sort_order" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>功能标记 JSON</Label>
+            <Textarea v-model="planForm.feature_flags_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="grid gap-2 lg:col-span-2">
+            <Label>Meta JSON</Label>
+            <Textarea v-model="planForm.meta_text" rows="8" class="font-mono text-xs" />
+          </div>
+          <div class="flex justify-end gap-2 lg:col-span-2">
+            <Button variant="outline" @click="planDialogOpen = false">取消</Button>
+            <Button :disabled="saving" @click="submitPlan">{{ saving ? '保存中...' : '保存' }}</Button>
+          </div>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+  </div>
+</template>

--- a/src/views/admin/PluginRuntimePage.vue
+++ b/src/views/admin/PluginRuntimePage.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+const route = useRoute()
+
+const pluginID = computed(() => (typeof route.meta.pluginId === 'string' ? route.meta.pluginId : '-'))
+const pageTitle = computed(() => (typeof route.meta.pluginTitle === 'string' ? route.meta.pluginTitle : '插件页面'))
+const routePath = computed(() => route.path || '/')
+const metaJSON = computed(() => {
+  try {
+    return JSON.stringify(route.meta.pluginMeta ?? {}, null, 2)
+  } catch {
+    return '{}'
+  }
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div>
+      <h2 class="text-2xl font-bold tracking-tight">{{ pageTitle }}</h2>
+      <p class="text-muted-foreground">当前页面已经由插件运行时登记，但宿主后台没有为它提供专门的前端实现。</p>
+    </div>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>页面占位说明</CardTitle>
+        <CardDescription>这说明插件路由已经挂载成功，只是前端视图还没有映射到宿主后台组件。</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4 text-sm">
+        <div class="grid gap-3 md:grid-cols-2">
+          <div>
+            <div class="text-muted-foreground">插件 ID</div>
+            <div class="font-medium">{{ pluginID }}</div>
+          </div>
+          <div>
+            <div class="text-muted-foreground">页面路由</div>
+            <div class="font-medium">{{ routePath }}</div>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <div class="text-muted-foreground">页面元数据</div>
+          <pre class="overflow-x-auto rounded-lg border bg-muted/30 p-4 text-xs leading-6">{{ metaJSON }}</pre>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+</template>

--- a/src/views/admin/Plugins.vue
+++ b/src/views/admin/Plugins.vue
@@ -1,0 +1,835 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { adminAPI } from '@/api/admin'
+import type { AdminPlugin, AdminPluginDetail, AdminPluginRuntimeLog } from '@/api/types'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { notifyError, notifySuccess } from '@/utils/notify'
+import { confirmAction } from '@/utils/confirm'
+import { invalidateMountedAdminPluginPages } from '@/utils/plugin-runtime-pages'
+
+type PluginConfigSchemaType =
+  | 'string'
+  | 'text'
+  | 'number'
+  | 'boolean'
+  | 'select'
+  | 'json'
+
+interface PluginConfigOption {
+  label: string
+  rawValue: unknown
+  selectValue: string
+}
+
+interface PluginConfigField {
+  key: string
+  label: string
+  description: string
+  placeholder: string
+  type: PluginConfigSchemaType
+  required: boolean
+  multiline: boolean
+  rows: number
+  defaultValue: unknown
+  options: PluginConfigOption[]
+}
+
+const router = useRouter()
+const fileInput = ref<HTMLInputElement | null>(null)
+const loading = ref(false)
+const uploading = ref(false)
+const applyingRuntime = ref(false)
+const actionLoading = ref('')
+const detailOpen = ref(false)
+const detailLoading = ref(false)
+const configSaving = ref(false)
+const items = ref<AdminPlugin[]>([])
+const detail = ref<AdminPluginDetail | null>(null)
+const runtimeLogs = ref<AdminPluginRuntimeLog[]>([])
+const configText = ref('{}')
+const configMode = ref<'form' | 'json'>('json')
+const configFormValues = ref<Record<string, any>>({})
+const pagination = ref({ page: 1, page_size: 20, total: 0, total_page: 1 })
+const filters = reactive({ keyword: '', type: '__all__', status: '__all__' })
+
+const normalizeSelectValue = (value: string) => (value === '__all__' ? '' : value)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+const normalizeSchemaType = (rawType: unknown): PluginConfigSchemaType => {
+  const value = String(rawType || 'string').trim().toLowerCase()
+  if (['number', 'int', 'integer', 'float', 'double'].includes(value)) return 'number'
+  if (['bool', 'boolean', 'switch', 'toggle'].includes(value)) return 'boolean'
+  if (['text', 'textarea', 'multiline'].includes(value)) return 'text'
+  if (['select', 'enum', 'radio'].includes(value)) return 'select'
+  if (['json', 'object', 'array', 'map'].includes(value)) return 'json'
+  return 'string'
+}
+
+const normalizeFieldOptions = (value: unknown): PluginConfigOption[] => {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item, index) => {
+      if (isRecord(item)) {
+        const rawValue = item.value ?? item.id ?? item.key ?? item.label ?? item.name ?? ''
+        const label = String((item.label ?? item.name ?? item.title ?? rawValue) || `选项 ${index + 1}`)
+        return { label, rawValue, selectValue: String(index) }
+      }
+      return {
+        label: String(item),
+        rawValue: item,
+        selectValue: String(index),
+      }
+    })
+    .filter((item) => item.label.trim() !== '')
+}
+
+const normalizeConfigSchema = (schema: Record<string, unknown> | undefined | null): PluginConfigField[] => {
+  if (!schema || !isRecord(schema)) return []
+  return Object.entries(schema).map(([key, rawValue]) => {
+    if (typeof rawValue === 'string') {
+      const type = normalizeSchemaType(rawValue)
+      return {
+        key,
+        label: key,
+        description: '',
+        placeholder: '',
+        type,
+        required: false,
+        multiline: type === 'text',
+        rows: type === 'text' ? 4 : 5,
+        defaultValue: type === 'boolean' ? false : type === 'json' ? {} : '',
+        options: [],
+      }
+    }
+
+    if (Array.isArray(rawValue)) {
+      const options = normalizeFieldOptions(rawValue)
+      return {
+        key,
+        label: key,
+        description: '',
+        placeholder: '',
+        type: options.length ? 'select' : 'json',
+        required: false,
+        multiline: false,
+        rows: 5,
+        defaultValue: options.length ? options[0]?.rawValue ?? '' : rawValue,
+        options,
+      }
+    }
+
+    if (isRecord(rawValue)) {
+      const options = normalizeFieldOptions(rawValue.options)
+      const inferredType = rawValue.type ?? (options.length ? 'select' : 'string')
+      const type = normalizeSchemaType(inferredType)
+      return {
+        key,
+        label: String(rawValue.label ?? rawValue.title ?? rawValue.name ?? key),
+        description: String(rawValue.description ?? rawValue.help ?? rawValue.hint ?? ''),
+        placeholder: String(rawValue.placeholder ?? ''),
+        type: options.length && type === 'string' ? 'select' : type,
+        required: Boolean(rawValue.required),
+        multiline: Boolean(rawValue.multiline) || type === 'text',
+        rows: Number(rawValue.rows || (type === 'text' ? 4 : 5)) || 5,
+        defaultValue: rawValue.default ?? (type === 'boolean' ? false : type === 'json' ? {} : ''),
+        options,
+      }
+    }
+
+    return {
+      key,
+      label: key,
+      description: '',
+      placeholder: '',
+      type: 'string',
+      required: false,
+      multiline: false,
+      rows: 5,
+      defaultValue: rawValue ?? '',
+      options: [],
+    }
+  })
+}
+
+const pluginConfigFields = computed(() => normalizeConfigSchema(detail.value?.plugin?.config_schema))
+const hasVisualConfigSchema = computed(() => pluginConfigFields.value.length > 0)
+
+const getRawConfigObject = () => {
+  const value = detail.value?.config
+  return isRecord(value) ? { ...value } : {}
+}
+
+const serializeJSONValue = (value: unknown) => {
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2)
+    } catch {
+      return value
+    }
+  }
+  return JSON.stringify(value ?? {}, null, 2)
+}
+
+const buildFieldInitialValue = (field: PluginConfigField, source: Record<string, unknown>) => {
+  const hasValue = Object.prototype.hasOwnProperty.call(source, field.key)
+  const currentValue = hasValue ? source[field.key] : field.defaultValue
+  switch (field.type) {
+    case 'boolean':
+      return Boolean(currentValue)
+    case 'number':
+      return currentValue === null || currentValue === undefined ? '' : String(currentValue)
+    case 'select': {
+      const matched = field.options.find((item) => item.rawValue === currentValue)
+      if (matched) return matched.selectValue
+      const fallback = field.options.find((item) => item.rawValue === field.defaultValue)
+      return fallback?.selectValue ?? ''
+    }
+    case 'json':
+      return serializeJSONValue(currentValue ?? field.defaultValue)
+    default:
+      return currentValue === null || currentValue === undefined ? '' : String(currentValue)
+  }
+}
+
+const syncConfigEditor = (detailValue: AdminPluginDetail | null) => {
+  const currentConfig = detailValue?.config && isRecord(detailValue.config) ? detailValue.config : {}
+  configText.value = JSON.stringify(currentConfig, null, 2)
+  const nextFormValues: Record<string, any> = {}
+  const fields = normalizeConfigSchema(detailValue?.plugin?.config_schema)
+  fields.forEach((field) => {
+    nextFormValues[field.key] = buildFieldInitialValue(field, currentConfig)
+  })
+  configFormValues.value = nextFormValues
+  configMode.value = fields.length > 0 ? 'form' : 'json'
+}
+
+const parseJSONFieldValue = (field: PluginConfigField, rawValue: unknown) => {
+  const text = String(rawValue ?? '').trim()
+  if (!text) {
+    if (field.required) {
+      throw new Error(`配置项「${field.label}」不能为空`)
+    }
+    return undefined
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new Error(`配置项「${field.label}」不是合法 JSON`)
+  }
+}
+
+const buildConfigPayloadFromForm = () => {
+  const payload: Record<string, unknown> = { ...getRawConfigObject() }
+  for (const field of pluginConfigFields.value) {
+    const rawValue = configFormValues.value[field.key]
+    switch (field.type) {
+      case 'boolean':
+        payload[field.key] = Boolean(rawValue)
+        break
+      case 'number': {
+        const text = String(rawValue ?? '').trim()
+        if (!text) {
+          if (field.required) {
+            throw new Error(`配置项「${field.label}」不能为空`)
+          }
+          delete payload[field.key]
+          break
+        }
+        const parsed = Number(text)
+        if (!Number.isFinite(parsed)) {
+          throw new Error(`配置项「${field.label}」必须是数字`)
+        }
+        payload[field.key] = parsed
+        break
+      }
+      case 'select': {
+        if (!String(rawValue ?? '').trim()) {
+          if (field.required) {
+            throw new Error(`请选择配置项「${field.label}」`)
+          }
+          delete payload[field.key]
+          break
+        }
+        const matched = field.options.find((item) => item.selectValue === rawValue)
+        payload[field.key] = matched?.rawValue ?? rawValue
+        break
+      }
+      case 'json': {
+        const parsed = parseJSONFieldValue(field, rawValue)
+        if (parsed === undefined) {
+          delete payload[field.key]
+        } else {
+          payload[field.key] = parsed
+        }
+        break
+      }
+      default: {
+        const text = String(rawValue ?? '')
+        if (!text.trim() && field.required) {
+          throw new Error(`配置项「${field.label}」不能为空`)
+        }
+        payload[field.key] = text
+        break
+      }
+    }
+  }
+  return payload
+}
+
+const setConfigMode = (nextMode: 'form' | 'json') => {
+  if (nextMode === configMode.value) return
+  if (nextMode === 'json') {
+    try {
+      configText.value = JSON.stringify(buildConfigPayloadFromForm(), null, 2)
+    } catch (err: any) {
+      notifyError(err?.message || '当前表单配置有误，无法切换到 JSON 模式')
+      return
+    }
+    configMode.value = 'json'
+    return
+  }
+
+  try {
+    const raw = JSON.parse(configText.value || '{}')
+    if (!isRecord(raw)) {
+      notifyError('原始 JSON 必须是对象')
+      return
+    }
+    const nextFormValues: Record<string, any> = {}
+    pluginConfigFields.value.forEach((field) => {
+      nextFormValues[field.key] = buildFieldInitialValue(field, raw)
+    })
+    configFormValues.value = nextFormValues
+    configMode.value = 'form'
+  } catch (err: any) {
+    notifyError(err instanceof SyntaxError ? '当前 JSON 格式不正确，无法切换到表单模式' : err?.message || '切换配置模式失败')
+  }
+}
+
+const booleanSelectValue = (fieldKey: string) => (configFormValues.value[fieldKey] ? 'true' : 'false')
+
+const fetchPlugins = async (page = 1) => {
+  loading.value = true
+  try {
+    const response = await adminAPI.getPlugins({
+      page,
+      page_size: pagination.value.page_size,
+      keyword: filters.keyword.trim() || undefined,
+      type: normalizeSelectValue(filters.type) || undefined,
+      status: normalizeSelectValue(filters.status) || undefined,
+    })
+    items.value = response.data?.data || []
+    pagination.value = response.data?.pagination || pagination.value
+  } catch (err: any) {
+    items.value = []
+    notifyError(err?.response?.data?.msg || err?.message || '加载插件列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const fetchDetail = async (id: string) => {
+  if (!id) return
+  detailLoading.value = true
+  try {
+    const [detailRes, logRes] = await Promise.all([
+      adminAPI.getPlugin(id),
+      adminAPI.getPluginLogs(id, { page: 1, page_size: 20 }),
+    ])
+    detail.value = detailRes.data?.data || null
+    runtimeLogs.value = logRes.data?.data || []
+    syncConfigEditor(detail.value)
+    detailOpen.value = true
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '加载插件详情失败')
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const triggerUpload = () => fileInput.value?.click()
+
+const onFileChange = async (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+  const formData = new FormData()
+  formData.append('file', file)
+  uploading.value = true
+  try {
+    await adminAPI.uploadPlugin(formData)
+    notifySuccess('插件包上传成功')
+    await fetchPlugins(1)
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '插件包上传失败')
+  } finally {
+    uploading.value = false
+    target.value = ''
+  }
+}
+
+const executeAction = async (actionKey: string, executor: () => Promise<any>, successText: string, refreshDetail = true) => {
+  actionLoading.value = actionKey
+  try {
+    await executor()
+    notifySuccess(successText)
+    await fetchPlugins(pagination.value.page)
+    if (refreshDetail && detail.value?.plugin?.id) {
+      await fetchDetail(detail.value.plugin.id)
+    }
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || `${successText}失败`)
+  } finally {
+    actionLoading.value = ''
+  }
+}
+
+const installPlugin = async (plugin: AdminPlugin) => executeAction(`install:${plugin.id}`, () => adminAPI.installPlugin(plugin.id), '插件安装成功')
+const enablePlugin = async (plugin: AdminPlugin) => executeAction(`enable:${plugin.id}`, () => adminAPI.enablePlugin(plugin.id), '插件已启用，等待应用运行时变更')
+const disablePlugin = async (plugin: AdminPlugin) => executeAction(`disable:${plugin.id}`, () => adminAPI.disablePlugin(plugin.id), '插件已禁用，等待应用运行时变更')
+const rollbackPlugin = async (plugin: AdminPlugin) => executeAction(`rollback:${plugin.id}`, () => adminAPI.rollbackPlugin(plugin.id), '插件版本已切换，等待应用运行时变更')
+
+const applyRuntimeChanges = async () => {
+  applyingRuntime.value = true
+  const currentDetailID = detail.value?.plugin?.id || ''
+  const currentDetailStatus = detail.value?.plugin?.status || ''
+  try {
+    await adminAPI.applyPluginRuntimeChanges()
+    invalidateMountedAdminPluginPages()
+    window.dispatchEvent(new Event('admin-plugin-runtime-pages-changed'))
+    notifySuccess('插件运行时变更已应用')
+    await fetchPlugins(pagination.value.page)
+    if (currentDetailID) {
+      if (currentDetailStatus === 'remove_pending_restart') {
+        detailOpen.value = false
+        detail.value = null
+        runtimeLogs.value = []
+      } else {
+        await fetchDetail(currentDetailID)
+      }
+    }
+  } catch (err: any) {
+    notifyError(err?.response?.data?.msg || err?.message || '应用插件运行时变更失败')
+  } finally {
+    applyingRuntime.value = false
+  }
+}
+
+const removePlugin = async (plugin: AdminPlugin) => {
+  const confirmed = await confirmAction({
+    description: `确定移除插件 ${plugin.name}（${plugin.id}）吗？`,
+    confirmText: '移除',
+    variant: 'destructive',
+  })
+  if (!confirmed) return
+  await executeAction(`remove:${plugin.id}`, () => adminAPI.deletePlugin(plugin.id, { purge: true }), '插件已标记移除，应用运行时变更后完成清理')
+}
+
+const saveConfig = async () => {
+  if (!detail.value?.plugin?.id) return
+  configSaving.value = true
+  try {
+    const payload = hasVisualConfigSchema.value && configMode.value === 'form'
+      ? buildConfigPayloadFromForm()
+      : JSON.parse(configText.value || '{}')
+    if (!isRecord(payload)) {
+      notifyError('插件配置必须是 JSON 对象')
+      return
+    }
+    await adminAPI.updatePluginConfig(detail.value.plugin.id, payload)
+    notifySuccess('插件配置已保存')
+    await fetchDetail(detail.value.plugin.id)
+  } catch (err: any) {
+    if (err instanceof SyntaxError) {
+      notifyError('插件配置 JSON 格式不正确')
+    } else if (err instanceof Error) {
+      notifyError(err.message || '保存插件配置失败')
+    } else {
+      notifyError(err?.response?.data?.msg || err?.message || '保存插件配置失败')
+    }
+  } finally {
+    configSaving.value = false
+  }
+}
+
+const typeLabel = (value?: string) => {
+  const map: Record<string, string> = { theme: '模板', payment: '支付', feature: '功能' }
+  return map[value || ''] || value || '-'
+}
+
+const statusLabel = (value?: string) => {
+  const map: Record<string, string> = {
+    uploaded: '已上传',
+    installed: '已安装',
+    enabled: '已启用',
+    disabled: '已禁用',
+    load_failed: '加载失败',
+    upgrade_pending_restart: '待重载生效',
+    remove_pending_restart: '待重载删除',
+  }
+  return map[value || ''] || value || '-'
+}
+
+const statusVariant = (value?: string) => {
+  switch (value) {
+    case 'enabled': return 'default'
+    case 'load_failed': return 'destructive'
+    case 'upgrade_pending_restart': return 'secondary'
+    case 'remove_pending_restart': return 'destructive'
+    default: return 'outline'
+  }
+}
+
+const canInstall = (plugin: AdminPlugin) => ['uploaded'].includes(plugin.status)
+const canEnable = (plugin: AdminPlugin) => !plugin.is_enabled && ['installed', 'disabled', 'upgrade_pending_restart'].includes(plugin.status)
+const canDisable = (plugin: AdminPlugin) => plugin.is_enabled
+const canRollback = (plugin: AdminPlugin) => !!plugin.current_version
+
+const activeVersion = computed(() => detail.value?.versions?.find((item) => item.is_active) || null)
+const pendingChangeCount = computed(() => items.value.filter((item) => item.needs_restart).length)
+const hasPendingChanges = computed(() => pendingChangeCount.value > 0)
+
+onMounted(() => {
+  fetchPlugins(1)
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold">插件中心</h1>
+        <p class="text-sm text-muted-foreground">管理本地导入插件、版本切换、运行状态与插件配置。</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <Button variant="outline" @click="router.push('/plugin-market')">在线插件库</Button>
+        <Button variant="outline" :disabled="uploading" @click="triggerUpload">{{ uploading ? '上传中...' : '导入插件包' }}</Button>
+        <input ref="fileInput" type="file" accept=".zip,.tar.gz,.tgz" class="hidden" @change="onFileChange" />
+      </div>
+    </div>
+
+    <Card v-if="hasPendingChanges" class="border-amber-200 bg-amber-50/60">
+      <CardContent class="flex flex-col gap-3 p-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="space-y-1 text-sm">
+          <div class="font-medium text-amber-950">有 {{ pendingChangeCount }} 个插件变更待应用</div>
+          <div class="text-amber-900/80">启用、禁用、回滚和删除会先进入待重载状态，点击这里统一应用运行时变更。</div>
+        </div>
+        <Button :disabled="applyingRuntime" @click="applyRuntimeChanges">{{ applyingRuntime ? '应用中...' : '应用运行时变更' }}</Button>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>筛选条件</CardTitle>
+      </CardHeader>
+      <CardContent class="flex flex-col gap-3 lg:flex-row">
+        <Input v-model="filters.keyword" placeholder="按插件 ID / 名称 / 作者搜索" @keyup.enter="fetchPlugins(1)" />
+        <Select v-model="filters.type" @update:modelValue="fetchPlugins(1)">
+          <SelectTrigger class="w-full lg:w-40"><SelectValue placeholder="全部类型" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部类型</SelectItem>
+            <SelectItem value="theme">模板</SelectItem>
+            <SelectItem value="payment">支付</SelectItem>
+            <SelectItem value="feature">功能</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select v-model="filters.status" @update:modelValue="fetchPlugins(1)">
+          <SelectTrigger class="w-full lg:w-52"><SelectValue placeholder="全部状态" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">全部状态</SelectItem>
+            <SelectItem value="uploaded">已上传</SelectItem>
+            <SelectItem value="installed">已安装</SelectItem>
+            <SelectItem value="enabled">已启用</SelectItem>
+            <SelectItem value="disabled">已禁用</SelectItem>
+            <SelectItem value="load_failed">加载失败</SelectItem>
+            <SelectItem value="upgrade_pending_restart">待重载生效</SelectItem>
+            <SelectItem value="remove_pending_restart">待重载删除</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button class="lg:w-auto" @click="fetchPlugins(1)">搜索</Button>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardContent class="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead class="w-[240px]">插件</TableHead>
+              <TableHead>类型</TableHead>
+              <TableHead>来源</TableHead>
+              <TableHead>版本</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead class="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow v-if="loading">
+              <TableCell colspan="6" class="py-8 text-center text-muted-foreground">正在加载插件列表...</TableCell>
+            </TableRow>
+            <TableRow v-else-if="items.length === 0">
+              <TableCell colspan="6" class="py-8 text-center text-muted-foreground">暂无插件数据</TableCell>
+            </TableRow>
+            <TableRow v-for="plugin in items" :key="plugin.id">
+              <TableCell>
+                <div class="space-y-1">
+                  <div class="font-medium">{{ plugin.name }}</div>
+                  <div class="text-xs text-muted-foreground">{{ plugin.id }}</div>
+                  <div class="text-xs text-muted-foreground">作者：{{ plugin.author || '-' }}</div>
+                </div>
+              </TableCell>
+              <TableCell>{{ typeLabel(plugin.type) }}</TableCell>
+              <TableCell>{{ plugin.source || '-' }}</TableCell>
+              <TableCell>
+                <div class="space-y-1 text-xs">
+                  <div>当前：{{ plugin.current_version || '-' }}</div>
+                  <div class="text-muted-foreground">待生效：{{ plugin.pending_version || '-' }}</div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <div class="space-y-2">
+                  <Badge :variant="statusVariant(plugin.status) as any">{{ statusLabel(plugin.status) }}</Badge>
+                  <div v-if="plugin.last_error" class="max-w-xs text-xs text-rose-500 line-clamp-2">{{ plugin.last_error }}</div>
+                </div>
+              </TableCell>
+              <TableCell class="text-right">
+                <div class="flex flex-wrap justify-end gap-2">
+                  <Button size="sm" variant="outline" @click="fetchDetail(plugin.id)">详情</Button>
+                  <Button size="sm" variant="outline" :disabled="!canInstall(plugin) || actionLoading === `install:${plugin.id}`" @click="installPlugin(plugin)">安装</Button>
+                  <Button size="sm" variant="outline" :disabled="!canEnable(plugin) || actionLoading === `enable:${plugin.id}`" @click="enablePlugin(plugin)">启用</Button>
+                  <Button size="sm" variant="outline" :disabled="!canDisable(plugin) || actionLoading === `disable:${plugin.id}`" @click="disablePlugin(plugin)">禁用</Button>
+                  <Button size="sm" variant="outline" :disabled="!canRollback(plugin) || actionLoading === `rollback:${plugin.id}`" @click="rollbackPlugin(plugin)">回滚</Button>
+                  <Button size="sm" variant="destructive" :disabled="actionLoading === `remove:${plugin.id}`" @click="removePlugin(plugin)">删除</Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+
+    <div class="flex items-center justify-between text-sm text-muted-foreground">
+      <div>共 {{ pagination.total }} 条记录</div>
+      <div class="flex gap-2">
+        <Button size="sm" variant="outline" :disabled="pagination.page <= 1" @click="fetchPlugins(pagination.page - 1)">上一页</Button>
+        <Button size="sm" variant="outline" :disabled="pagination.page >= pagination.total_page" @click="fetchPlugins(pagination.page + 1)">下一页</Button>
+      </div>
+    </div>
+
+    <Dialog v-model:open="detailOpen">
+      <DialogScrollContent class="w-[calc(100vw-1rem)] max-w-6xl p-4 sm:p-6">
+        <DialogHeader>
+          <DialogTitle>插件详情</DialogTitle>
+        </DialogHeader>
+        <div v-if="detailLoading" class="py-10 text-center text-sm text-muted-foreground">正在加载插件详情...</div>
+        <div v-else-if="detail" class="space-y-6">
+          <div class="grid gap-4 lg:grid-cols-3">
+            <Card>
+              <CardHeader><CardTitle class="text-base">基础信息</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div><span class="text-muted-foreground">插件：</span>{{ detail.plugin.name }}（{{ detail.plugin.id }}）</div>
+                <div><span class="text-muted-foreground">类型：</span>{{ typeLabel(detail.plugin.type) }}</div>
+                <div><span class="text-muted-foreground">版本：</span>{{ activeVersion?.version || detail.plugin.current_version || '-' }}</div>
+                <div><span class="text-muted-foreground">状态：</span>{{ statusLabel(detail.plugin.status) }}</div>
+                <div><span class="text-muted-foreground">宿主协议：</span>{{ detail.plugin.host_api_version || '-' }}</div>
+                <div><span class="text-muted-foreground">Go 版本：</span>{{ detail.plugin.go_version || '-' }}</div>
+                <div><span class="text-muted-foreground">构建目标：</span>{{ detail.plugin.build_target || '-' }}</div>
+                <div><span class="text-muted-foreground">入口符号：</span>{{ detail.plugin.entry_symbol || '-' }}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">权限与运行态</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div class="flex flex-wrap gap-2">
+                  <Badge v-for="permission in detail.plugin.permissions || []" :key="permission" variant="outline">{{ permission }}</Badge>
+                  <span v-if="!detail.plugin.permissions?.length" class="text-muted-foreground">未声明权限</span>
+                </div>
+                <div><span class="text-muted-foreground">运行时：</span>{{ detail.runtime_loaded ? '已加载' : '未加载' }}</div>
+                <div><span class="text-muted-foreground">需要重载：</span>{{ detail.plugin.needs_restart ? '是' : '否' }}</div>
+                <div v-if="detail.plugin.last_loaded_at"><span class="text-muted-foreground">最近加载：</span>{{ detail.plugin.last_loaded_at }}</div>
+                <div v-if="detail.plugin.last_error" class="text-rose-500"><span class="text-muted-foreground">最近错误：</span>{{ detail.plugin.last_error }}</div>
+                <div class="flex flex-wrap gap-2 pt-2">
+                  <Button size="sm" variant="outline" :disabled="applyingRuntime" @click="applyRuntimeChanges">应用运行时变更</Button>
+                  <Button size="sm" variant="outline" :disabled="actionLoading === `enable:${detail.plugin.id}`" @click="enablePlugin(detail.plugin)">启用</Button>
+                  <Button size="sm" variant="outline" :disabled="actionLoading === `disable:${detail.plugin.id}`" @click="disablePlugin(detail.plugin)">禁用</Button>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">版本记录</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div v-for="version in detail.versions" :key="version.id" class="rounded-lg border p-3">
+                  <div class="flex items-center justify-between gap-2">
+                    <div class="font-medium">{{ version.version }}</div>
+                    <Badge :variant="version.is_active ? 'default' : 'outline'">{{ version.is_active ? '当前生效' : statusLabel(version.status) }}</Badge>
+                  </div>
+                  <div class="mt-2 text-xs text-muted-foreground break-all">{{ version.install_path || version.package_path || '-' }}</div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div class="grid gap-4 lg:grid-cols-2">
+            <Card>
+              <CardHeader><CardTitle class="text-base">插件配置</CardTitle></CardHeader>
+              <CardContent class="space-y-3">
+                <div v-if="hasVisualConfigSchema" class="space-y-4">
+                  <div class="rounded-lg border border-emerald-200 bg-emerald-50/60 p-3 text-sm text-emerald-950">
+                    插件已声明 `config_schema`，当前优先使用可视化表单编辑；如需补充高级字段，可切换到原始 JSON。
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <Button size="sm" :variant="configMode === 'form' ? 'default' : 'outline'" @click="setConfigMode('form')">表单模式</Button>
+                    <Button size="sm" :variant="configMode === 'json' ? 'default' : 'outline'" @click="setConfigMode('json')">原始 JSON</Button>
+                  </div>
+
+                  <div v-if="configMode === 'form'" class="grid gap-4">
+                    <div v-for="field in pluginConfigFields" :key="field.key" class="space-y-2 rounded-lg border p-4">
+                      <div class="space-y-1">
+                        <Label :for="`plugin-config-${field.key}`">{{ field.label }}</Label>
+                        <div class="text-xs text-muted-foreground">
+                          <span>{{ field.key }}</span>
+                          <span v-if="field.required"> · 必填</span>
+                          <span v-if="field.description"> · {{ field.description }}</span>
+                        </div>
+                      </div>
+
+                      <Input
+                        v-if="field.type === 'string' && !field.multiline"
+                        :id="`plugin-config-${field.key}`"
+                        v-model="configFormValues[field.key]"
+                        :placeholder="field.placeholder || `请输入 ${field.label}`"
+                      />
+
+                      <Textarea
+                        v-else-if="field.type === 'text'"
+                        :id="`plugin-config-${field.key}`"
+                        v-model="configFormValues[field.key]"
+                        :rows="field.rows"
+                        :placeholder="field.placeholder || `请输入 ${field.label}`"
+                      />
+
+                      <Input
+                        v-else-if="field.type === 'number'"
+                        :id="`plugin-config-${field.key}`"
+                        v-model="configFormValues[field.key]"
+                        type="number"
+                        :placeholder="field.placeholder || `请输入 ${field.label}`"
+                      />
+
+                      <Select
+                        v-else-if="field.type === 'boolean'"
+                        :model-value="booleanSelectValue(field.key)"
+                        @update:model-value="(value) => { configFormValues[field.key] = value === 'true' }"
+                      >
+                        <SelectTrigger :id="`plugin-config-${field.key}`">
+                          <SelectValue placeholder="请选择" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="true">开启 / true</SelectItem>
+                          <SelectItem value="false">关闭 / false</SelectItem>
+                        </SelectContent>
+                      </Select>
+
+                      <Select
+                        v-else-if="field.type === 'select'"
+                        :model-value="configFormValues[field.key]"
+                        @update:model-value="(value) => { configFormValues[field.key] = value }"
+                      >
+                        <SelectTrigger :id="`plugin-config-${field.key}`">
+                          <SelectValue :placeholder="field.placeholder || '请选择'" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem v-for="option in field.options" :key="`${field.key}-${option.selectValue}`" :value="option.selectValue">
+                            {{ option.label }}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+
+                      <Textarea
+                        v-else
+                        :id="`plugin-config-${field.key}`"
+                        v-model="configFormValues[field.key]"
+                        :rows="field.rows"
+                        class="font-mono text-xs"
+                        :placeholder="field.placeholder || `请输入 ${field.label} 的 JSON 值`"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div v-if="!hasVisualConfigSchema || configMode === 'json'" class="space-y-3">
+                  <div v-if="!hasVisualConfigSchema" class="rounded-lg border border-slate-200 bg-slate-50/70 p-3 text-sm text-slate-700">
+                    插件未声明 `config_schema`，当前使用原始 JSON 编辑模式。
+                  </div>
+                  <Textarea v-model="configText" rows="14" class="font-mono text-xs" />
+                </div>
+
+                <div class="flex justify-end">
+                  <Button :disabled="configSaving" @click="saveConfig">{{ configSaving ? '保存中...' : '保存配置' }}</Button>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">运行日志</CardTitle></CardHeader>
+              <CardContent class="space-y-3">
+                <div v-if="runtimeLogs.length === 0" class="text-sm text-muted-foreground">暂无运行日志</div>
+                <div v-for="log in runtimeLogs" :key="log.id" class="rounded-lg border p-3 text-sm">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="font-medium">{{ log.message }}</div>
+                    <Badge variant="outline">{{ log.level }}</Badge>
+                  </div>
+                  <div class="mt-1 text-xs text-muted-foreground">{{ log.event_type }} · {{ log.created_at }}</div>
+                  <pre class="mt-2 overflow-x-auto rounded bg-muted p-2 text-xs">{{ JSON.stringify(log.details || {}, null, 2) }}</pre>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div class="grid gap-4 lg:grid-cols-3">
+            <Card>
+              <CardHeader><CardTitle class="text-base">路由登记</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div v-if="detail.routes.length === 0" class="text-muted-foreground">暂无路由登记</div>
+                <div v-for="item in detail.routes" :key="item.id" class="rounded-lg border p-3">
+                  <div class="font-medium">{{ item.scope }} · {{ item.path }}</div>
+                  <div class="mt-1 text-xs text-muted-foreground">{{ (item.methods || []).join(' / ') || 'ANY' }}</div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">页面登记</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div v-if="detail.pages.length === 0" class="text-muted-foreground">暂无页面登记</div>
+                <div v-for="item in detail.pages" :key="item.id" class="rounded-lg border p-3">
+                  <div class="font-medium">{{ item.title || item.route_path }}</div>
+                  <div class="mt-1 text-xs text-muted-foreground">{{ item.scope }} · {{ item.route_path }}</div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle class="text-base">事件订阅</CardTitle></CardHeader>
+              <CardContent class="space-y-2 text-sm">
+                <div v-if="detail.events.length === 0" class="text-muted-foreground">暂无事件订阅</div>
+                <div v-for="item in detail.events" :key="item.id" class="rounded-lg border p-3">
+                  <div class="font-medium">{{ item.event_type }}</div>
+                  <pre class="mt-2 overflow-x-auto rounded bg-muted p-2 text-xs">{{ JSON.stringify(item.meta || {}, null, 2) }}</pre>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </DialogScrollContent>
+    </Dialog>
+  </div>
+</template>


### PR DESCRIPTION
## 变更范围

本 PR 包含插件中心平台能力相关后台改动：

- 后台插件中心页面
- 在线插件库页面
- 在线插件中心页面
- 在线授权中心页面
- 运行时插件页壳与后台路由接入

## 本地验证

- `npm run build`

## 关联 PR

- API: `5SSR:codex/plugin-center-api`
- User: `5SSR:codex/plugin-center-user`
